### PR TITLE
Add pytest stub and make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: up down clear logs data
+.PHONY: up down clear logs data test
 
 SERVICES = enrich fanout reader replay dashboard grafana
 SEED     = seed
@@ -24,3 +24,6 @@ logs:
 data:
 	python tools/make_cc_csv.py 50000 data/news_sample.csv
 	@echo "CSV ready → data/news_sample.csv"
+
+test:
+	pytest -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,76 @@
+import sys, types
+
+class DummyMetric:
+    def inc(self, *a, **k):
+        pass
+    def set(self, *a, **k):
+        pass
+    def labels(self, *a, **k):
+        return self
+    def time(self):
+        class Ctx:
+            def __enter__(self):
+                pass
+            def __exit__(self, exc_type, exc, tb):
+                pass
+        return Ctx()
+
+dummy_prom = types.SimpleNamespace(
+    Counter=lambda *a, **k: DummyMetric(),
+    Histogram=lambda *a, **k: DummyMetric(),
+    Gauge=lambda *a, **k: DummyMetric(),
+    start_http_server=lambda *a, **k: None,
+)
+
+dummy_asyncio = types.ModuleType("redis.asyncio")
+async def dummy_from_url(*a, **k):
+    raise RuntimeError("from_url not patched")
+dummy_asyncio.from_url = dummy_from_url
+
+class DummyExc(Exception):
+    pass
+
+dummy_exceptions = types.SimpleNamespace(ConnectionError=DummyExc, ResponseError=DummyExc)
+
+dummy_redis = types.ModuleType("redis")
+dummy_redis.asyncio = dummy_asyncio
+dummy_redis.exceptions = dummy_exceptions
+
+class DummyGraph:
+    def add_node(self, *a, **k):
+        pass
+    def add_edge(self, *a, **k):
+        pass
+    def set_entry_point(self, *a, **k):
+        pass
+    def set_finish_point(self, *a, **k):
+        pass
+    def compile(self):
+        class Chain:
+            def invoke(self, data):
+                return data
+        return Chain()
+
+dummy_graph_mod = types.ModuleType("langgraph.graph")
+dummy_graph_mod.Graph = DummyGraph
+
+class RunnableLambda:
+    def __init__(self, fn):
+        self.fn = fn
+
+dummy_runnables = types.ModuleType("langchain_core.runnables")
+dummy_runnables.RunnableLambda = RunnableLambda
+
+dummy_transformers = types.ModuleType("transformers")
+dummy_transformers.pipeline = lambda *a, **k: None
+
+
+def pytest_configure(config):
+    sys.modules.setdefault("redis", dummy_redis)
+    sys.modules.setdefault("redis.asyncio", dummy_asyncio)
+    sys.modules.setdefault("redis.exceptions", dummy_exceptions)
+    sys.modules.setdefault("prometheus_client", dummy_prom)
+    sys.modules.setdefault("langgraph.graph", dummy_graph_mod)
+    sys.modules.setdefault("langchain_core.runnables", dummy_runnables)
+    sys.modules.setdefault("transformers", dummy_transformers)
+

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -1,0 +1,65 @@
+import sys, importlib
+import asyncio
+import pytest
+
+# create dummy pipeline to avoid heavy model load
+class DummyPipe:
+    def __init__(self, out):
+        self.out = out
+    def __call__(self, inputs, *a, **kw):
+        return [self.out for _ in range(len(inputs))]
+
+def load_module(monkeypatch):
+    def fake_pipeline(task, *a, **kw):
+        if task == "zero-shot-classification":
+            return DummyPipe({"labels": ["tech"]})
+        elif task == "summarization":
+            return DummyPipe({"summary_text": "sum"})
+        return DummyPipe({})
+    monkeypatch.setattr("transformers.pipeline", fake_pipeline)
+    sys.modules.pop("agents.enrich", None)
+    return importlib.import_module("agents.enrich")
+
+@pytest.mark.asyncio
+async def test_rconn(monkeypatch):
+    mod = load_module(monkeypatch)
+    class Stub:
+        async def ping(self):
+            pass
+    async def fake_from_url(url, decode_responses=True):
+        return Stub()
+    monkeypatch.setattr(mod.redis, "from_url", fake_from_url)
+    conn = await mod.rconn()
+    assert isinstance(conn, Stub)
+
+@pytest.mark.asyncio
+async def test_rconn_retry(monkeypatch):
+    mod = load_module(monkeypatch)
+    class Stub:
+        async def ping(self):
+            pass
+    calls = {"n": 0}
+    async def fake_from_url(url, decode_responses=True):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise Exception("fail")
+        return Stub()
+    monkeypatch.setattr(mod.redis, "from_url", fake_from_url)
+    async def noop(*_a, **_k):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", noop)
+    conn = await mod.rconn()
+    assert isinstance(conn, Stub)
+    assert calls["n"] >= 2
+
+def test_pick_topic(monkeypatch):
+    mod = load_module(monkeypatch)
+    batch = [{"title": "t", "body": "b"}]
+    out = mod.pick_topic(batch)
+    assert out[0]["topic"] == "tech"
+
+def test_summarise(monkeypatch):
+    mod = load_module(monkeypatch)
+    batch = [{"body": "b"}]
+    out = mod.summarise(batch)
+    assert out[0]["summary"] == "sum"

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -1,0 +1,37 @@
+import sys, importlib
+import asyncio
+import pytest
+
+class DummyRedis:
+    def __init__(self):
+        self.loaded = None
+    async def script_load(self, lua):
+        self.loaded = lua
+        return "sha123"
+    async def ping(self):
+        pass
+
+async def fake_from_url(url, decode_responses=True):
+    return DummyRedis()
+
+def load_module(monkeypatch):
+    sys.modules.pop("agents.fanout", None)
+    return importlib.import_module("agents.fanout")
+
+@pytest.mark.asyncio
+async def test_rconn(monkeypatch):
+    mod = load_module(monkeypatch)
+    monkeypatch.setattr(mod.redis, "from_url", fake_from_url)
+    conn = await mod.rconn()
+    assert isinstance(conn, DummyRedis)
+
+@pytest.mark.asyncio
+async def test_load_sha(monkeypatch, tmp_path):
+    mod = load_module(monkeypatch)
+    script = tmp_path/"fanout.lua"
+    script.write_text("return 1")
+    monkeypatch.setattr(mod, "open", lambda *_: open(script, 'r'))
+    redis_inst = DummyRedis()
+    sha = await mod.load_sha(redis_inst)
+    assert sha == "sha123"
+    assert redis_inst.loaded == "return 1"

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,41 @@
+import sys, importlib
+import asyncio
+import pytest
+
+class DummyRedis:
+    def __init__(self):
+        self.adds = []
+    async def ping(self):
+        pass
+    async def xadd(self, name, data):
+        self.adds.append((name, data))
+
+def load_mod(monkeypatch):
+    sys.modules.pop("agents.replay", None)
+    return importlib.import_module("agents.replay")
+
+@pytest.mark.asyncio
+async def test_redis_ready(monkeypatch):
+    mod = load_mod(monkeypatch)
+    async def fake_from_url(url, decode_responses=True):
+        return DummyRedis()
+    monkeypatch.setattr(mod.redis, "from_url", fake_from_url)
+    conn = await mod.redis_ready()
+    assert isinstance(conn, DummyRedis)
+
+@pytest.mark.asyncio
+async def test_main(monkeypatch, tmp_path):
+    csvfile = tmp_path / "sample.csv"
+    csvfile.write_text("id,title,text\n1,a,b\n2,c,d\n")
+    mod = load_mod(monkeypatch)
+    monkeypatch.setenv("REPLAY_FILE", str(csvfile))
+    dummy = DummyRedis()
+    async def rr():
+        return dummy
+    monkeypatch.setattr(mod, "redis_ready", rr)
+    monkeypatch.setattr(mod, "start_http_server", lambda *a, **k: None)
+    async def sleep(*_a, **_k):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+    await mod.main()
+    assert len(dummy.adds) == 2

--- a/tests/test_user_reader.py
+++ b/tests/test_user_reader.py
@@ -1,0 +1,42 @@
+import sys, importlib
+import asyncio
+import pytest
+
+class DummyRedis:
+    def __init__(self):
+        self.popped = 0
+    async def ping(self):
+        pass
+    async def get(self, key):
+        return "5"
+    async def brpop(self, key, timeout=1):
+        self.popped += 1
+
+
+def load_mod(monkeypatch):
+    sys.modules.pop("agents.user_reader", None)
+    return importlib.import_module("agents.user_reader")
+
+@pytest.mark.asyncio
+async def test_rconn(monkeypatch):
+    mod = load_mod(monkeypatch)
+    async def fake_from_url(url, decode_responses=True):
+        return DummyRedis()
+    monkeypatch.setattr(mod.redis, "from_url", fake_from_url)
+    conn = await mod.rconn()
+    assert isinstance(conn, DummyRedis)
+
+@pytest.mark.asyncio
+async def test_main_single_loop(monkeypatch):
+    dummy = DummyRedis()
+    mod = load_mod(monkeypatch)
+    async def fake_rconn():
+        return dummy
+    monkeypatch.setattr(mod, "rconn", fake_rconn)
+    monkeypatch.setattr(mod, "start_http_server", lambda *a, **k: None)
+    async def stop(*_a, **_k):
+        raise RuntimeError("stop")
+    monkeypatch.setattr(asyncio, "sleep", stop)
+    with pytest.raises(RuntimeError):
+        await mod.main()
+    assert dummy.popped == 1

--- a/tests/test_user_seeder.py
+++ b/tests/test_user_seeder.py
@@ -1,0 +1,54 @@
+import sys, importlib
+import asyncio
+import pytest
+
+class DummyJSON:
+    def __init__(self, outer):
+        self.outer = outer
+    async def set(self, key, path, obj):
+        self.outer.json_set = (key, path, obj)
+
+class DummyRedis:
+    def __init__(self):
+        self.json_obj = DummyJSON(self)
+        self.zcalls = []
+        self.set_latest = None
+    def json(self):
+        return self.json_obj
+    async def zadd(self, key, data):
+        self.zcalls.append((key, data))
+    async def set(self, key, val):
+        self.set_latest = (key, val)
+    async def ping(self):
+        pass
+
+def load_mod(monkeypatch):
+    sys.modules.pop("agents.user_seeder", None)
+    return importlib.import_module("agents.user_seeder")
+
+@pytest.mark.asyncio
+async def test_rconn(monkeypatch):
+    mod = load_mod(monkeypatch)
+    async def from_url(url, decode_responses=True):
+        return DummyRedis()
+    monkeypatch.setattr(mod.redis, "from_url", from_url)
+    conn = await mod.rconn()
+    assert isinstance(conn, DummyRedis)
+
+@pytest.mark.asyncio
+async def test_main_single(monkeypatch):
+    dummy = DummyRedis()
+    mod = load_mod(monkeypatch)
+    async def fake_rconn():
+        return dummy
+    monkeypatch.setattr(mod, "rconn", fake_rconn)
+    monkeypatch.setattr(mod, "start_http_server", lambda *a, **k: None)
+    monkeypatch.setattr(mod.random, "sample", lambda seq, k: seq[:k])
+    monkeypatch.setattr(mod.random, "randint", lambda a,b: 2)
+    async def stop(*_a, **_k):
+        raise RuntimeError("stop")
+    monkeypatch.setattr(asyncio, "sleep", stop)
+    with pytest.raises(RuntimeError):
+        await mod.main()
+    assert dummy.set_latest == ("latest_uid", 0)
+    assert dummy.zcalls


### PR DESCRIPTION
## Summary
- add testing scaffold that stubs dependencies used by agents
- include a new `test` target in the Makefile

## Testing
- `make test` *(fails: `pytest: No such file or directory`)*