### PR TITLE
Fix tests import path

### DIFF
--- a/agents/fanout.py
+++ b/agents/fanout.py
@@ -1,6 +1,10 @@
 import os, json, asyncio, redis.asyncio as redis
 from redis.exceptions import ConnectionError as RedisConnError
 from prometheus_client import Counter, Gauge, start_http_server
+from builtins import open as builtin_open
+
+# expose builtin open so tests can monkeypatch mod.open
+open = builtin_open
 
 VALKEY = os.getenv("VALKEY_URL", "redis://valkey:6379")
 TOPICS = ["politics","business","technology","sports","health",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
-import sys, types
+import sys, types, pathlib
+
+# ensure project root is on import path
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
 class DummyMetric:
     def inc(self, *a, **k):


### PR DESCRIPTION
## Summary
- ensure project root is added to `sys.path` in tests
- expose builtin `open` for easier monkeypatching
- read replay configuration values at runtime

## Testing
- `make test` *(fails: pytest not installed)*