### PR TITLE
Fix ec2 helper search path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test:
 	python -m pytest -q
 
 ec2-up: ## Spin up an EC2 g5.xlarge
-	python scripts/ec2_up.py $(ARGS)
+	PYTHONPATH=$(CURDIR) python scripts/ec2_up.py $(ARGS)
 
 ec2-down: ## Terminate the EC2 created by ec2-up
-	python scripts/ec2_down.py $(ARGS)
+	PYTHONPATH=$(CURDIR) python scripts/ec2_down.py $(ARGS)

--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ make ec2-up
 ```
 The helper defaults to a GPU-enabled AMI so you can simply run `make ec2-up`
 against AWS.  Pass `--image-id` to override if needed.
+
+To use the helper scripts with real AWS, install the `boto3` package and do not
+set `USE_MOCK_BOTO3`:
+
+```bash
+pip install boto3
+unset USE_MOCK_BOTO3
+make ec2-up
+```

--- a/scripts/ec2_down.py
+++ b/scripts/ec2_down.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 from pathlib import Path
 from valkey_agentic_demo import boto3shim as boto3
 
@@ -8,6 +9,21 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--infile", default="instance_id.txt")
     args = parser.parse_args()
+
+    if not os.getenv("USE_MOCK_BOTO3"):
+        try:
+            subprocess.run(
+                ["aws", "sts", "get-caller-identity"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            print("aws CLI not found")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"aws CLI failed: {e.stderr.decode().strip()}")
+            raise
 
     iid = Path(args.infile).read_text().strip()
 

--- a/scripts/ec2_up.py
+++ b/scripts/ec2_up.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import subprocess
 from valkey_agentic_demo import boto3shim as boto3
 
 
@@ -12,6 +13,21 @@ def main() -> None:
     parser.add_argument("--instance-type", default=os.getenv("INSTANCE_TYPE", "g5.xlarge"))
     parser.add_argument("--outfile", default="instance_id.txt")
     args = parser.parse_args()
+
+    if not os.getenv("USE_MOCK_BOTO3"):
+        try:
+            subprocess.run(
+                ["aws", "sts", "get-caller-identity"],
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        except FileNotFoundError:
+            print("aws CLI not found")
+            raise
+        except subprocess.CalledProcessError as e:
+            print(f"aws CLI failed: {e.stderr.decode().strip()}")
+            raise
 
     ec2 = boto3.client(
         "ec2",

--- a/valkey_agentic_demo/boto3shim.py
+++ b/valkey_agentic_demo/boto3shim.py
@@ -7,8 +7,8 @@ if os.getenv("USE_MOCK_BOTO3"):
 else:
     try:
         import boto3  # type: ignore
-    except ImportError:  # pragma: no cover - fallback when boto3 not installed
-        import boto3_mock as boto3  # noqa: F401
+    except ImportError:  # pragma: no cover - defer error until client call
+        boto3 = None  # type: ignore
     else:
         if not hasattr(boto3, "reset"):
             def _noop():
@@ -17,8 +17,42 @@ else:
 
 _state = getattr(boto3, "_state", None)
 
+
+class LoggingClient:
+    """Wrapper around a boto3 client that logs each call."""
+
+    def __init__(self, real_client):
+        self._real = real_client
+
+    def __getattr__(self, name):
+        attr = getattr(self._real, name)
+        if callable(attr):
+            def wrapper(*args, **kwargs):
+                svc = getattr(getattr(self._real, "meta", None),
+                              "service_model", None)
+                svc_name = getattr(svc, "service_name", "unknown")
+                print(f"boto3 {svc_name}.{name}(")
+                if args:
+                    print(f"  args={args}")
+                if kwargs:
+                    print(f"  kwargs={kwargs}")
+                print(")")
+                return attr(*args, **kwargs)
+            return wrapper
+        return attr
+
+
 def client(*a, **k):
-    return boto3.client(*a, **k)
+    if boto3 is None:
+        raise ImportError(
+            "boto3 is required when USE_MOCK_BOTO3 is not set. "
+            "Install it with 'pip install boto3' or set USE_MOCK_BOTO3=1 to "
+            "use the built-in mock."
+        )
+    print(f"boto3.client(args={a}, kwargs={k})")
+    real = boto3.client(*a, **k)
+    return LoggingClient(real)
 
 def reset():
-    return boto3.reset()
+    if boto3 is not None:
+        return boto3.reset()


### PR DESCRIPTION
## Summary
- require AWS CLI for ec2 helper scripts
- log all boto3 commands
- improve boto3 shim to raise errors when boto3 missing
- document installing boto3 for real AWS

## Testing
- `python -m pytest -q`
- `make ec2-up` (fails: `FileNotFoundError: [Errno 2] No such file or directory: 'aws'`)
