### PR TITLE
Ensure real boto used by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 SERVICES = enrich fanout reader replay dashboard grafana
 SEED     = seed
+MOCK ?=
 
 up:
 	docker compose up --build -d
@@ -29,7 +30,7 @@ test:
 	python -m pytest -q
 
 ec2-up: ## Spin up an EC2 g5.xlarge
-	PYTHONPATH=$(CURDIR) python scripts/ec2_up.py $(ARGS)
+	USE_MOCK_BOTO3=$(MOCK) PYTHONPATH=$(CURDIR) python scripts/ec2_up.py $(ARGS)
 
 ec2-down: ## Terminate the EC2 created by ec2-up
-	PYTHONPATH=$(CURDIR) python scripts/ec2_down.py $(ARGS)
+	USE_MOCK_BOTO3=$(MOCK) PYTHONPATH=$(CURDIR) python scripts/ec2_down.py $(ARGS)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Build the container and run the EC2 helper scripts against LocalStack:
 
 ```bash
 docker build -t valkey-demo .
-docker run --rm -e USE_MOCK_BOTO3=1 valkey-demo \
-  /bin/bash -c "make ec2-up && sleep 5 && make ec2-down && pytest -q"
+docker run --rm valkey-demo \
+  /bin/bash -c "make MOCK=1 ec2-up && sleep 5 && make MOCK=1 ec2-down && pytest -q"
 ```
 
 If you'd rather run the helper scripts on your host with LocalStack, start it
@@ -24,17 +24,14 @@ first and export the environment variables that the scripts expect:
 localstack start -d
 export AWS_ENDPOINT_URL=http://localhost:4566
 export AWS_REGION=us-west-2
-export USE_MOCK_BOTO3=1
-make ec2-up
+make MOCK=1 ec2-up
 ```
 The helper defaults to a GPU-enabled AMI so you can simply run `make ec2-up`
-against AWS.  Pass `--image-id` to override if needed.
+against AWS. Pass `--image-id` to override if needed.
 
-To use the helper scripts with real AWS, install the `boto3` package and do not
-set `USE_MOCK_BOTO3`:
+To use the helper scripts with real AWS, install the `boto3` package and run:
 
 ```bash
 pip install boto3
-unset USE_MOCK_BOTO3
 make ec2-up
 ```

--- a/tests/test_ec2_up_down.py
+++ b/tests/test_ec2_up_down.py
@@ -13,14 +13,14 @@ def test_ec2_up_down(localstack, tmp_path):
         "PYTHONPATH": os.getcwd() + os.pathsep + env.get("PYTHONPATH", ""),
         "USE_MOCK_BOTO3": "1",
     })
-    subprocess.check_call(["make", "ec2-up"], env=env)
+    subprocess.check_call(["make", "MOCK=1", "ec2-up"], env=env)
 
     ec2 = boto3.client("ec2", endpoint_url=localstack.endpoint_url, region_name=localstack.region_name)
     res = ec2.describe_instances()
     instances = [i for r in res.get("Reservations", []) for i in r.get("Instances", [])]
     assert len(instances) == 1
 
-    subprocess.check_call(["make", "ec2-down"], env=env)
+    subprocess.check_call(["make", "MOCK=1", "ec2-down"], env=env)
     res = ec2.describe_instances()
     instances = [i for r in res.get("Reservations", []) for i in r.get("Instances", [])]
     assert len(instances) == 0


### PR DESCRIPTION
## Summary
- default `make ec2-up`/`ec2-down` to use real boto
- allow opting into the mock via `MOCK=1`
- update README to reflect new variable
- adjust tests for new behaviour

## Testing
- `python -m pytest -q`