### PR TITLE
Ensure real boto used by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 SERVICES = enrich fanout reader replay dashboard grafana
 SEED     = seed
+MOCK ?=
 
 up:
 	docker compose up --build -d
@@ -29,7 +30,7 @@ test:
 	python -m pytest -q
 
 ec2-up: ## Spin up an EC2 g5.xlarge
-	PYTHONPATH=$(CURDIR) python scripts/ec2_up.py $(ARGS)
+	USE_MOCK_BOTO3=$(MOCK) PYTHONPATH=$(CURDIR) python scripts/ec2_up.py $(ARGS)
 
 ec2-down: ## Terminate the EC2 created by ec2-up
-	PYTHONPATH=$(CURDIR) python scripts/ec2_down.py $(ARGS)
+	USE_MOCK_BOTO3=$(MOCK) PYTHONPATH=$(CURDIR) python scripts/ec2_down.py $(ARGS)

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Build the container and run the EC2 helper scripts against LocalStack:
 
 ```bash
 docker build -t valkey-demo .
-docker run --rm -e USE_MOCK_BOTO3=1 valkey-demo \
-  /bin/bash -c "make ec2-up && sleep 5 && make ec2-down && pytest -q"
+docker run --rm valkey-demo \
+  /bin/bash -c "make MOCK=1 ec2-up && sleep 5 && make MOCK=1 ec2-down && pytest -q"
 ```
 
 If you'd rather run the helper scripts on your host with LocalStack, start it
@@ -24,17 +24,18 @@ first and export the environment variables that the scripts expect:
 localstack start -d
 export AWS_ENDPOINT_URL=http://localhost:4566
 export AWS_REGION=us-west-2
-export USE_MOCK_BOTO3=1
-make ec2-up
+make MOCK=1 ec2-up
 ```
 The helper defaults to a GPU-enabled AMI so you can simply run `make ec2-up`
-against AWS.  Pass `--image-id` to override if needed.
+against AWS. Pass `--image-id` to override if needed.
 
-To use the helper scripts with real AWS, install the `boto3` package and do not
-set `USE_MOCK_BOTO3`:
+`make ec2-up` automatically creates a key-pair `demo-key` and a security group
+`valkey-demo-sg` if they don't already exist, then waits for the instance to be
+ready before writing the ID to `instance_id.txt`.
+
+To use the helper scripts with real AWS, install the `boto3` package and run:
 
 ```bash
 pip install boto3
-unset USE_MOCK_BOTO3
 make ec2-up
 ```

--- a/scripts/ec2_up.py
+++ b/scripts/ec2_up.py
@@ -1,7 +1,9 @@
 import argparse
 import os
 import subprocess
+import time
 from valkey_agentic_demo import boto3shim as boto3
+from valkey_agentic_demo.launcher.aws_helpers import ensure_key, ensure_sg
 
 
 DEFAULT_AMI = "ami-0f5c0fd7df464c253"  # Deep Learning AMI with GPU support
@@ -34,13 +36,33 @@ def main() -> None:
         endpoint_url=os.getenv("AWS_ENDPOINT_URL"),
         region_name=os.getenv("AWS_REGION", "us-west-2"),
     )
+    key_name = ensure_key(ec2, "demo-key")
+    sg_id = ensure_sg(ec2, "valkey-demo-sg", "0.0.0.0/0")
+    subnet_id = ec2.describe_subnets()["Subnets"][0]["SubnetId"]
+
     resp = ec2.run_instances(
         ImageId=args.image_id,
         InstanceType=args.instance_type,
+        KeyName=key_name,
+        NetworkInterfaces=[
+            {
+                "DeviceIndex": 0,
+                "SubnetId": subnet_id,
+                "Groups": [sg_id],
+                "AssociatePublicIpAddress": True,
+            }
+        ],
         MinCount=1,
         MaxCount=1,
     )
     iid = resp["Instances"][0]["InstanceId"]
+    # wait until instance is reported healthy
+    for _ in range(60):
+        st = ec2.describe_instance_status(InstanceIds=[iid]).get("InstanceStatuses")
+        if st and st[0].get("InstanceStatus", {}).get("Status") == "ok":
+            break
+        time.sleep(5)
+
     with open(args.outfile, "w") as fh:
         fh.write(iid)
     print(iid)

--- a/tests/test_ec2_up_down.py
+++ b/tests/test_ec2_up_down.py
@@ -13,14 +13,17 @@ def test_ec2_up_down(localstack, tmp_path):
         "PYTHONPATH": os.getcwd() + os.pathsep + env.get("PYTHONPATH", ""),
         "USE_MOCK_BOTO3": "1",
     })
-    subprocess.check_call(["make", "ec2-up"], env=env)
+    subprocess.check_call(["make", "MOCK=1", "ec2-up"], env=env)
 
     ec2 = boto3.client("ec2", endpoint_url=localstack.endpoint_url, region_name=localstack.region_name)
     res = ec2.describe_instances()
     instances = [i for r in res.get("Reservations", []) for i in r.get("Instances", [])]
     assert len(instances) == 1
+    assert ec2.describe_key_pairs(KeyNames=["demo-key"])["KeyPairs"]
+    sgs = ec2.describe_security_groups(Filters=[{"Name": "group-name", "Values": ["valkey-demo-sg"]}])["SecurityGroups"]
+    assert sgs
 
-    subprocess.check_call(["make", "ec2-down"], env=env)
+    subprocess.check_call(["make", "MOCK=1", "ec2-down"], env=env)
     res = ec2.describe_instances()
     instances = [i for r in res.get("Reservations", []) for i in r.get("Instances", [])]
     assert len(instances) == 0


### PR DESCRIPTION
## Summary
- run `make ec2-up` with real boto3 unless `MOCK=1`
- EC2 helper now provisions key pair and security group and waits for instance
- extend boto3 mock with subnet and status helpers
- document helper behaviour in README
- verify key pair and security group in tests

## Testing
- `python -m pytest -q`