### PR TITLE
Manage EC2 networking resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ make MOCK=1 ec2-up
 The helper defaults to a GPU-enabled AMI so you can simply run `make ec2-up`
 against AWS. Pass `--image-id` to override if needed.
 
-`make ec2-up` automatically creates a key-pair `demo-key` and a security group
-`valkey-demo-sg` if they don't already exist, then waits for the instance to be
-ready before writing the ID to `instance_id.txt`.
+`make ec2-up` automatically creates a key-pair `demo-key`, a subnet, a network
+interface and a security group `valkey-demo-sg` if they don't already exist.
+The resulting resource IDs are written to `instance_id.txt`, `sg_id.txt`,
+`subnet_id.txt` and `eni_id.txt`.
 
 To use the helper scripts with real AWS, install the `boto3` package and run:
 

--- a/scripts/ec2_down.py
+++ b/scripts/ec2_down.py
@@ -8,6 +8,9 @@ from valkey_agentic_demo import boto3shim as boto3
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--infile", default="instance_id.txt")
+    parser.add_argument("--sg-file", default="sg_id.txt")
+    parser.add_argument("--subnet-file", default="subnet_id.txt")
+    parser.add_argument("--eni-file", default="eni_id.txt")
     args = parser.parse_args()
 
     if not os.getenv("USE_MOCK_BOTO3"):
@@ -26,6 +29,9 @@ def main() -> None:
             raise
 
     iid = Path(args.infile).read_text().strip()
+    sg_id = Path(args.sg_file).read_text().strip()
+    subnet_id = Path(args.subnet_file).read_text().strip()
+    eni_id = Path(args.eni_file).read_text().strip()
 
     ec2 = boto3.client(
         "ec2",
@@ -33,6 +39,10 @@ def main() -> None:
         region_name=os.getenv("AWS_REGION"),
     )
     ec2.terminate_instances(InstanceIds=[iid])
+    ec2.delete_network_interface(NetworkInterfaceId=eni_id)
+    ec2.delete_security_group(GroupId=sg_id)
+    if hasattr(ec2, "delete_subnet"):
+        ec2.delete_subnet(SubnetId=subnet_id)
     print(iid)
 
 


### PR DESCRIPTION
## Summary
- expand boto3 mock to handle subnets, ENIs and SG deletion
- create subnet and network interface in `ec2_up.py` and save their ids
- remove ENI, SG and subnet in `ec2_down.py`
- document new resource files in README
- test that subnets and ENIs are created and removed
- handle missing subnet APIs

## Testing
- `python -m pytest -q`
