### PR TITLE
Fix test isolation for boto3 mock

### DIFF
--- a/pytest/__init__.py
+++ b/pytest/__init__.py
@@ -104,6 +104,8 @@ def run_test(func):
     kwargs = {}
     sig = inspect.signature(func)
     mod = importlib.import_module(func.__module__)
+    from valkey_agentic_demo import boto3shim
+    boto3shim.reset()
     for name in sig.parameters:
         if name == 'monkeypatch':
             kwargs[name] = mp
@@ -122,6 +124,7 @@ def run_test(func):
     except Exception as e:
         print(func.__name__, 'error', e)
         result = False
+    boto3shim.reset()
     mp.undo()
     tmp.cleanup()
     return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,4 +79,6 @@ def pytest_configure(config):
     sys.modules.setdefault("langgraph.graph", dummy_graph_mod)
     sys.modules.setdefault("langchain_core.runnables", dummy_runnables)
     sys.modules.setdefault("transformers", dummy_transformers)
+    # ensure boto3shim registers the mocked boto3 implementation
+    import valkey_agentic_demo.boto3shim  # noqa: F401
 


### PR DESCRIPTION
## Summary
- reset boto3 mock state between tests to prevent cross-test contamination
- load boto3shim during pytest configuration so moto sees the mocked boto3

## Testing
- `make test`