### PR TITLE
Fix CLI parsing and add subcommand descriptions

### DIFF
--- a/internal/cobra/command.go
+++ b/internal/cobra/command.go
@@ -10,9 +10,6 @@ type Command struct {
 	Short string
 	Long  string
 
-	SilenceUsage  bool
-	SilenceErrors bool
-
 	RunE func(cmd *Command, args []string) error
 
 	flagSet     *flag.FlagSet


### PR DESCRIPTION
## Summary
- improve short descriptions for CLI subcommands
- parse root flags before handling subcommands
- remove unused fields from hand-rolled cobra

## Testing
- `go vet ./...`
- `staticcheck ./...` *(fails: command not found)*
- `golangci-lint run`
- `go test ./...`
