### PR TITLE
Update requirements for Python 3.8 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 redis>=5.0.0
-numpy>=1.26,<2
+numpy>=1.24,<2
 prometheus_client>=0.19.0
-transformers>=4.51.3
+transformers>=4.25,<4.47
 torch==2.2.1
 langchain-community>=0.2.0
 langchain-ollama>=0.1.0
-langgraph>=0.0.30
+langgraph @ git+https://github.com/langchain-ai/langgraph.git@v0.0.30
 datasets>=2.18.0
 tqdm>=4.66.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-import sys, types
+import os, sys, types
 
 class DummyMetric:
     def inc(self, *a, **k):
@@ -66,6 +66,9 @@ dummy_transformers.pipeline = lambda *a, **k: None
 
 
 def pytest_configure(config):
+    root = os.path.dirname(os.path.dirname(__file__))
+    if root not in sys.path:
+        sys.path.insert(0, root)
     sys.modules.setdefault("redis", dummy_redis)
     sys.modules.setdefault("redis.asyncio", dummy_asyncio)
     sys.modules.setdefault("redis.exceptions", dummy_exceptions)


### PR DESCRIPTION
## Summary
- pin LangGraph to GitHub source so `pip install` works
- bound Transformers version for Python 3.8

## Testing
- `pytest -q`