### PR TITLE
Fix pytest discovery

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)


### PR DESCRIPTION
## Summary
- ensure tests import the project root by inserting the path in `tests/__init__`

## Testing
- `pytest -q`
