### PR TITLE
Add README and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Valkey contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,36 @@
 # Valkey Agentic Demo 🚀
 
-Scaffolding generated **2025-05-08T20:34:10Z**.
+This repository contains a small end‑to‑end demo built around [Valkey](https://valkey.io) that showcases an asynchronous agentic pipeline.  Several microservices communicate via Valkey streams and publish metrics for Grafana via Prometheus.
+
+## Running the demo
+
+The easiest way to spin everything up is with Docker Compose.  Make sure Docker and Python 3.8+ are installed, then run:
 
 ```bash
-# spin everything up
 make dev
 ```
+
+This will build the containers, generate a small dataset and launch the services defined in `docker-compose.yml`.  When the stack is up you can explore:
+
+* **Grafana** dashboards at <http://localhost:3000>
+* **Prometheus** metrics at <http://localhost:9090>
+* **Dashboard** UI at <http://localhost:8501>
+
+To tear everything down run `make down` (or `make clear` to remove volumes).
+
+## Tests
+
+Basic unit tests live under the `tests/` directory and can be run with:
+
+```bash
+make test
+```
+
+## Contents
+
+* `agents/` – microservices forming the data pipeline
+* `tools/`  – helper scripts for bootstrapping demo data
+* `valkey/` – Valkey Docker image with JSON module
+* `demo.sh` and `manage.py` – utilities for launching a demo EC2 host
+
+Feel free to modify the services or compose file to experiment further!


### PR DESCRIPTION
## Summary
- document how to run the Valkey agentic demo in Docker
- add a brief contents section describing the repo structure
- include an MIT license for the project

## Testing
- `make test`