### PR TITLE
Fix failing tests in fanout and replay

### DIFF
--- a/agents/fanout.py
+++ b/agents/fanout.py
@@ -1,5 +1,9 @@
 import os, json, asyncio, redis.asyncio as redis
 from redis.exceptions import ConnectionError as RedisConnError
+from builtins import open as builtin_open
+
+# alias built-in open so tests can monkeypatch this module's open()
+open = builtin_open
 from prometheus_client import Counter, Gauge, start_http_server
 
 VALKEY = os.getenv("VALKEY_URL", "redis://valkey:6379")

--- a/agents/replay.py
+++ b/agents/replay.py
@@ -17,10 +17,11 @@ async def redis_ready():
 
 async def main():
     start_http_server(9114)           # expose producer counter
+    csv_path = os.getenv("REPLAY_FILE", CSV)
     try:
-        fp = open(CSV, newline="", encoding="utf-8")
+        fp = open(csv_path, newline="", encoding="utf-8")
     except FileNotFoundError:
-        raise SystemExit(f"[replay] '{CSV}' missing in container")
+        raise SystemExit(f"[replay] '{csv_path}' missing in container")
 
     reader = csv.DictReader(fp)
     r = await redis_ready()


### PR DESCRIPTION
## Summary
- expose built-in `open` as a module attribute in `agents.fanout` so it can be monkeypatched
- fetch `REPLAY_FILE` path at runtime in `agents.replay` so tests can override it

## Testing
- `pytest -q`