### PR TITLE
Add optional CUDA support for PyTorch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,12 @@ ENV HF_HUB_DISABLE_XET=1
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir torch==2.2.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html
+ARG USE_CUDA=0
+RUN if [ "$USE_CUDA" = "1" ]; then \
+        pip install --no-cache-dir torch==2.2.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html ; \
+    else \
+        pip install --no-cache-dir torch==2.2.1 ; \
+    fi
 COPY agents ./agents
 COPY fanout.lua ./fanout.lua
 CMD ["python","-m","pip","--version"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The easiest way to spin everything up is with Docker Compose.  Make sure Docker 
 make dev
 ```
 
+The base image installs a CPU build of PyTorch.  To enable CUDA support
+during the build, pass `--build-arg USE_CUDA=1` when invoking Docker
+Compose, e.g. `docker compose build --build-arg USE_CUDA=1`.
+
 This will build the containers, generate a small dataset and launch the services defined in `docker-compose.yml`.  When the stack is up you can explore:
 
 * **Grafana** dashboards at <http://localhost:3000>


### PR DESCRIPTION
## Summary
- make CUDA install optional via `USE_CUDA` build arg
- note how to enable CUDA builds in README

## Testing
- `pytest -q`