### PR TITLE
Enable CUDA build during manage.py setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,12 @@ ENV HF_HUB_DISABLE_XET=1
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir torch==2.2.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html
+ARG USE_CUDA=0
+RUN if [ "$USE_CUDA" = "1" ]; then \
+        pip install --no-cache-dir torch==2.2.1+cu118 -f https://download.pytorch.org/whl/torch_stable.html ; \
+    else \
+        pip install --no-cache-dir torch==2.2.1 ; \
+    fi
 COPY agents ./agents
 COPY fanout.lua ./fanout.lua
 CMD ["python","-m","pip","--version"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The easiest way to spin everything up is with Docker Compose.  Make sure Docker 
 make dev
 ```
 
+The base image installs a CPU build of PyTorch.  To enable CUDA support
+during the build, pass `--build-arg USE_CUDA=1` when invoking Docker
+Compose, e.g. `docker compose build --build-arg USE_CUDA=1`.
+
 This will build the containers, generate a small dataset and launch the services defined in `docker-compose.yml`.  When the stack is up you can explore:
 
 * **Grafana** dashboards at <http://localhost:3000>

--- a/manage.py
+++ b/manage.py
@@ -51,7 +51,7 @@ cd valkey_agentic_demo
 /usr/bin/python3.8 tools/make_cc_csv.py 50000 data/news_sample.csv
 /usr/bin/python3.8 tools/bootstrap_grafana.py
 export PATH=$PATH:/usr/local/bin
-/usr/local/bin/docker-compose pull 2>&1 | tee docker-compose.log
+/usr/local/bin/docker-compose build --build-arg USE_CUDA=1 2>&1 | tee docker-compose.log
 /usr/local/bin/docker-compose up -d   2>&1 | tee -a docker-compose.log
 EOSU
 """


### PR DESCRIPTION
## Summary
- build Docker images with `USE_CUDA=1` in manage.py's EC2 setup script

## Testing
- `pytest -q`
