### PR TITLE
Fix default Valkey URL

### DIFF
--- a/agents/enrich.py
+++ b/agents/enrich.py
@@ -19,7 +19,7 @@ from prometheus_client import Counter, Histogram, Gauge, start_http_server
 from transformers import pipeline
 
 # ────────── Configuration ─────────────────────────────────────────
-VALKEY = os.getenv("VALKEY_URL", "redis://valkey:6379")
+VALKEY = os.getenv("VALKEY_URL", "redis://localhost:6379")
 SOURCE = "news_raw"
 TOPICS = [
     "politics", "business", "technology", "sports", "health",

--- a/agents/fanout.py
+++ b/agents/fanout.py
@@ -6,7 +6,7 @@ from builtins import open as builtin_open
 open = builtin_open
 from prometheus_client import Counter, Gauge, start_http_server
 
-VALKEY = os.getenv("VALKEY_URL", "redis://valkey:6379")
+VALKEY = os.getenv("VALKEY_URL", "redis://localhost:6379")
 TOPICS = ["politics","business","technology","sports","health",
           "climate","science","education","entertainment","finance"]
 MAX_LEN = int(os.getenv("FEED_LEN", "100"))

--- a/agents/fetcher.py
+++ b/agents/fetcher.py
@@ -2,7 +2,7 @@ import asyncio, json, os, random, time
 import redis.asyncio as redis
 from prometheus_client import Counter, Histogram, start_http_server
 
-VALKEY_URL = os.getenv("VALKEY_URL", "redis://valkey:6379")
+VALKEY_URL = os.getenv("VALKEY_URL", "redis://localhost:6379")
 REDIS = None
 async def rconn():
     global REDIS

--- a/agents/replay.py
+++ b/agents/replay.py
@@ -2,7 +2,7 @@ import os, csv, asyncio, redis.asyncio as redis
 from redis.exceptions import ConnectionError as RedisConnError
 from prometheus_client import Counter, start_http_server
 
-VALKEY = os.getenv("VALKEY_URL", "redis://valkey:6379")
+VALKEY = os.getenv("VALKEY_URL", "redis://localhost:6379")
 CSV    = os.getenv("REPLAY_FILE", "data/news_sample.csv")
 RPS    = float(os.getenv("REPLAY_RATE", "250"))
 

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -6,7 +6,7 @@ import time
 import streamlit as st
 import redis.asyncio as redis
 
-VALKEY_URL = os.getenv("VALKEY_URL", "redis://valkey:6379")
+VALKEY_URL = os.getenv("VALKEY_URL", "redis://localhost:6379")
 FEED_LEN = int(os.getenv("FEED_LEN", "100"))
 
 async def rconn():

--- a/agents/user_reader.py
+++ b/agents/user_reader.py
@@ -3,7 +3,7 @@ import redis.asyncio as redis
 from redis.exceptions import ConnectionError as RedisConnError
 from prometheus_client import Counter, start_http_server
 
-VALKEY_URL = os.getenv("VALKEY_URL", "redis://valkey:6379")
+VALKEY_URL = os.getenv("VALKEY_URL", "redis://localhost:6379")
 
 async def rconn(retries=30, delay=1.0):
     "Retry until Valkey answers PING."

--- a/agents/user_seeder.py
+++ b/agents/user_seeder.py
@@ -3,7 +3,7 @@ import redis.asyncio as redis
 from redis.exceptions import ConnectionError as RedisConnError
 from prometheus_client import Counter, start_http_server
 
-VALKEY_URL = os.getenv("VALKEY_URL", "redis://valkey:6379")
+VALKEY_URL = os.getenv("VALKEY_URL", "redis://localhost:6379")
 
 async def rconn(retries=30, delay=1.0):
     "Retry until Valkey answers PING."


### PR DESCRIPTION
## Summary
- point all agent services to `localhost` by default so they can connect without Docker Compose networking

## Testing
- `make test`