### PR TITLE
Add feed metrics and Grafana updates

### DIFF
--- a/tests/test_user_reader.py
+++ b/tests/test_user_reader.py
@@ -11,6 +11,8 @@ class DummyRedis:
         return "5"
     async def brpop(self, key, timeout=1):
         self.popped += 1
+    async def llen(self, key):
+        return 0
 
 
 def load_mod(monkeypatch):

--- a/tools/bootstrap_grafana.py
+++ b/tools/bootstrap_grafana.py
@@ -51,7 +51,7 @@ panels = [
         3,
         0,
     ),
-    panel("Feeds backlog", ["feed_backlog"], 3, 1),
+    panel("Feeds backlog", ["sum(feed_len)"], 3, 1),
     panel("Valkey ops / s", ["rate(redis_commands_processed_total[1m])"], 4, 0),
     panel("Valkey mem MB", ["redis_memory_used_bytes/1024/1024"], 4, 1),
 ]


### PR DESCRIPTION
## Summary
- track feed push counts and feed lengths in fanout service
- record feed backlog length and latency in user reader
- show total feed backlog in Grafana
- update unit tests for new metrics

## Testing
- `pytest -q`