### PR TITLE
Start seed service automatically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
-.PHONY: up down clear logs data test
+.PHONY: dev down clear logs data test
 
 SERVICES = enrich fanout reader replay dashboard grafana
 SEED     = seed
 
-up:
+dev:
 	docker compose up --build -d
-	docker compose --profile $(SEED) up --build -d $(SEED)
 
 down:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,7 +40,6 @@ services:
   seed:
     <<: *base
     command: python agents/user_seeder.py
-    profiles: ["seed"]
     depends_on: [valkey]
 
   reader:


### PR DESCRIPTION
## Summary
- run the `seed` service by default in Docker Compose
- fix indentation of the `dev` target in `Makefile`

## Testing
- `pytest -q`
