### PR TITLE
Adjust enrich worker configuration

### DIFF
--- a/agents/enrich.py
+++ b/agents/enrich.py
@@ -5,6 +5,9 @@ Reads raw articles from `news_raw`, assigns a single topic and publishes the
 article ID + title to the corresponding `topic:<T>` stream so that the fan-out
 service can deliver it to user feeds.
 
+Environment variables:
+    ENRICH_BATCH – articles processed per batch (default: 32)
+
 Tiny DistilBERT-MNLI is still used because it is reasonably fast even on CPU,
 but you can swap it out for a simpler heuristic if desired.
 """
@@ -25,7 +28,7 @@ TOPICS = [
     "politics", "business", "technology", "sports", "health",
     "climate", "science", "education", "entertainment", "finance",
 ]
-BATCH = int(os.getenv("ENRICH_BATCH", "16"))   # articles per batch
+BATCH = int(os.getenv("ENRICH_BATCH", "32"))   # articles per batch
 TXT_CLF = 512                                  # characters fed to classifier
 
 # ────────── Lazy Redis connection helper ──────────────────────────

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
     depends_on: [valkey, prometheus]
+    deploy: {replicas: 2}
 
   fanout:
     <<: *base

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -13,8 +13,6 @@ def load_module(monkeypatch):
     def fake_pipeline(task, *a, **kw):
         if task == "zero-shot-classification":
             return DummyPipe({"labels": ["tech"]})
-        elif task == "summarization":
-            return DummyPipe({"summary_text": "sum"})
         return DummyPipe({})
     monkeypatch.setattr("transformers.pipeline", fake_pipeline)
     sys.modules.pop("agents.enrich", None)


### PR DESCRIPTION
## Summary
- document `ENRICH_BATCH` and default to `32`
- run two enrich workers via compose
- drop obsolete summarisation code in the enrichment tests

## Testing
- `python -m py_compile agents/enrich.py`
- `pytest -q`