### PR TITLE
Adjust enrich worker configuration

### DIFF
--- a/agents/enrich.py
+++ b/agents/enrich.py
@@ -5,6 +5,9 @@ Reads raw articles from `news_raw`, assigns a single topic and publishes the
 article ID + title to the corresponding `topic:<T>` stream so that the fan-out
 service can deliver it to user feeds.
 
+Environment variables:
+    ENRICH_BATCH – articles processed per batch (default: 32)
+
 Tiny DistilBERT-MNLI is still used because it is reasonably fast even on CPU,
 but you can swap it out for a simpler heuristic if desired.
 """
@@ -25,7 +28,7 @@ TOPICS = [
     "politics", "business", "technology", "sports", "health",
     "climate", "science", "education", "entertainment", "finance",
 ]
-BATCH = int(os.getenv("ENRICH_BATCH", "16"))   # articles per batch
+BATCH = int(os.getenv("ENRICH_BATCH", "32"))   # articles per batch
 TXT_CLF = 512                                  # characters fed to classifier
 
 # ────────── Lazy Redis connection helper ──────────────────────────
@@ -94,7 +97,8 @@ async def main() -> None:
             pipe = r.pipeline()
             for d in docs:
                 stream = f"topic:{d['topic']}"
-                pipe.xadd(stream, {"id": d["id"], "title": d["title"]})
+                payload = {"id": d["id"], "title": d["title"]}
+                pipe.xadd(stream, payload)
                 pipe.xtrim(stream, maxlen=10_000)
             await pipe.execute()
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
     depends_on: [valkey, prometheus]
+    deploy: {replicas: 2}
 
   fanout:
     <<: *base


### PR DESCRIPTION
## Summary
- document `ENRICH_BATCH` and default to `32`
- run two enrich workers via compose
- ensure topics publish document ID and title only

## Testing
- `python -m py_compile agents/enrich.py tests/test_enrich.py`
- `pytest -q`