### PR TITLE
Add expandable article view with tags

### DIFF
--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -75,10 +75,20 @@ if items:
     for item in items:
         title = item.get("title", "")
         summary = item.get("summary", "")
+        body = item.get("body", "")
+        tags = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
         ts = item.get("id", "")
-        body = f"**{title}**" + (f"\n\n{summary}" if summary else "")
-        st.markdown(body)
-        st.markdown(ts)
+
+        title_line = f"**{title}**"
+        with st.expander(title_line):
+            st.markdown(body)
+
+        tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
+        st.markdown(tag_html, unsafe_allow_html=True)
+        if summary:
+            st.markdown(summary)
+        if ts:
+            st.markdown(ts)
         st.markdown("<hr>", unsafe_allow_html=True)
     st.markdown("</div>", unsafe_allow_html=True)
 else:

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -81,14 +81,22 @@ st.subheader("Timeline")
 if feed:
     st.markdown("<div style='max-height:400px;overflow-y:auto'>", unsafe_allow_html=True)
     for item in feed:
-        text = item.get("summary") or item.get("title") or str(item)
-        topic = item.get("topic", "")
+        title = item.get("title", "")
+        summary = item.get("summary", "")
+        body = item.get("body", "")
+        tags = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
         ts = item.get("id", "")
-        st.markdown(
-            f"**{text}**\n\n"
-            f"<span class='tag-topic'>{topic}</span> {ts}",
-            unsafe_allow_html=True,
-        )
+
+        title_line = f"**{title}**"
+        with st.expander(title_line):
+            st.markdown(body)
+
+        tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
+        st.markdown(tag_html, unsafe_allow_html=True)
+        if summary:
+            st.markdown(summary)
+        if ts:
+            st.markdown(ts)
         st.markdown("<hr>", unsafe_allow_html=True)
     st.markdown("</div>", unsafe_allow_html=True)
 else:


### PR DESCRIPTION
## Summary
- include tags and body fields in enriched article payloads
- show expandable articles and tags in user feed UI
- show expandable articles and tags in topic page
- use body field from raw docs when enriching

## Testing
- `make test`
