### PR TITLE
Fix tag background color

### DIFF
--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -49,7 +49,7 @@ st.markdown(
     """
     <style>
     .tag-int {background:#ffeb3b;color:#000;border-radius:4px;padding:2px 6px;margin-right:4px}
-    .tag-topic {background:#eee;border-radius:4px;padding:2px 6px;margin-right:4px}
+    .tag-topic {background:#ffeb3b;color:#000;border-radius:4px;padding:2px 6px;margin-right:4px}
     </style>
     """,
     unsafe_allow_html=True,

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -47,7 +47,7 @@ st.markdown(
     """
     <style>
     .tag-int {background:#ffeb3b;color:#000;border-radius:4px;padding:2px 6px;margin-right:4px}
-    .tag-topic {background:#eee;border-radius:4px;padding:2px 6px;margin-right:4px}
+    .tag-topic {background:#ffeb3b;color:#000;border-radius:4px;padding:2px 6px;margin-right:4px}
     </style>
     """,
     unsafe_allow_html=True,


### PR DESCRIPTION
## Summary
- use the same bright background for topic tags as for interest tags in both UIs

## Testing
- `make test`
