### PR TITLE
Fix backlog gauge by trimming news_raw stream

### DIFF
--- a/agents/enrich.py
+++ b/agents/enrich.py
@@ -124,7 +124,7 @@ async def main() -> None:
 
             # Acknowledge and record metrics -----------------------------------------
             await r.xack(SOURCE, grp, *mids)
-            await r.xtrim(SOURCE, maxlen=NEWS_RAW_MAXLEN)
+            await r.xtrim(SOURCE, maxlen=NEWS_RAW_MAXLEN, approximate=False)
             TRIM_OPS.inc()
             IN_MSG.inc(len(docs))
             OUT_MSG.inc(len(docs))


### PR DESCRIPTION
## Summary
- trim `news_raw` exactly after each batch so that the `news_raw_len` gauge matches the real backlog
- test that the gauge value drops after trimming

## Testing
- `make test`