### PR TITLE
Switch timeline expanders to card containers

### DIFF
--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -83,22 +83,22 @@ if items:
     st.markdown("<div style='max-height:400px;overflow-y:auto'>", unsafe_allow_html=True)
     for item in items:
         title = item.get("title", "")
-        summary = item.get("summary", "")
+        summary = item.get("summary") or (item.get("body", "")[:300] + "…")
         body = item.get("body", "")
         tags = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
         ts = item.get("id", "")
 
-        title_line = f"**{title}**"
-        with st.expander(title_line):
-            st.markdown(body)
-
         tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
-        st.markdown(tag_html, unsafe_allow_html=True)
-        if summary:
-            st.markdown(summary)
-        if ts:
-            st.markdown(ts)
-        st.markdown("<hr>", unsafe_allow_html=True)
+
+        with st.container():
+            card = f"<div class='card'><h4>{title}</h4><p>{summary}</p>"
+            if body:
+                card += f"<details><summary>Read more</summary>{body}</details>"
+            card += f"<div class='tags'>{tag_html}</div></div>"
+            st.markdown(card, unsafe_allow_html=True)
+            if ts:
+                st.markdown(ts)
+            st.markdown("<hr>", unsafe_allow_html=True)
     st.markdown("</div>", unsafe_allow_html=True)
 else:
     st.info("No items yet")

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -84,22 +84,22 @@ if feed:
     st.markdown("<div style='max-height:400px;overflow-y:auto'>", unsafe_allow_html=True)
     for item in feed:
         title = item.get("title", "")
-        summary = item.get("summary", "")
+        summary = item.get("summary") or (item.get("body", "")[:300] + "…")
         body = item.get("body", "")
         tags = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
         ts = item.get("id", "")
 
-        title_line = f"**{title}**"
-        with st.expander(title_line):
-            st.markdown(body)
-
         tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
-        st.markdown(tag_html, unsafe_allow_html=True)
-        if summary:
-            st.markdown(summary)
-        if ts:
-            st.markdown(ts)
-        st.markdown("<hr>", unsafe_allow_html=True)
+
+        with st.container():
+            card = f"<div class='card'><h4>{title}</h4><p>{summary}</p>"
+            if body:
+                card += f"<details><summary>Read more</summary>{body}</details>"
+            card += f"<div class='tags'>{tag_html}</div></div>"
+            st.markdown(card, unsafe_allow_html=True)
+            if ts:
+                st.markdown(ts)
+            st.markdown("<hr>", unsafe_allow_html=True)
     st.markdown("</div>", unsafe_allow_html=True)
 else:
     st.info("No articles yet – try another uid or wait a bit…")

--- a/tests/test_topic_page.py
+++ b/tests/test_topic_page.py
@@ -34,7 +34,7 @@ class DummyStreamlit(types.ModuleType):
         pass
     def info(self, *a, **k):
         pass
-    def expander(self, *a, **k):
+    def container(self, *a, **k):
         return DummyExpander()
     def rerun(self):
         self.rerun_called = True


### PR DESCRIPTION
## Summary
- swap expander blocks for lightweight card containers in `agents/ui.py`
- apply the same card layout to the topic page
- adjust the topic page test helper for `st.container`

## Testing
- `make test`