### PR TITLE
Add autorefresh slider to UI pages

### DIFF
--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -3,6 +3,11 @@ import json
 import time
 
 import streamlit as st
+try:
+    from streamlit_autorefresh import st_autorefresh
+except Exception:  # pragma: no cover - fallback for tests without dependency
+    def st_autorefresh(*a, **k):
+        pass
 import redis
 
 rerun = getattr(st, "rerun", getattr(st, "experimental_rerun"))
@@ -54,6 +59,11 @@ st.markdown(
     """,
     unsafe_allow_html=True,
 )
+
+sidebar = getattr(st, "sidebar", st)
+slider = getattr(sidebar, "slider", None)
+interval = slider("Refresh (sec)", 1, 15, 5) if slider else 5
+st_autorefresh(interval * 1000, key="auto_refresh")
 
 r = rconn()
 

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -4,6 +4,11 @@ import time
 import random
 
 import streamlit as st
+try:
+    from streamlit_autorefresh import st_autorefresh
+except Exception:  # pragma: no cover - fallback for tests without dependency
+    def st_autorefresh(*a, **k):
+        pass
 import redis
 
 # Backward-compatible rerun function
@@ -52,6 +57,11 @@ st.markdown(
     """,
     unsafe_allow_html=True,
 )
+
+sidebar = getattr(st, "sidebar", st)
+slider = getattr(sidebar, "slider", None)
+interval = slider("Refresh (sec)", 1, 15, 5) if slider else 5
+st_autorefresh(interval * 1000, key="auto_refresh")
 
 r = rconn()
 lu = latest_uid(r)
@@ -105,7 +115,4 @@ else:
     st.info("No articles yet – try another uid or wait a bit…")
 
 if refresh:
-    rerun()
-else:
-    time.sleep(5)
     rerun()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ streamlit==1.34.0
 torch==2.2.1
 tqdm>=4.66.4
 transformers>=4.25,<4.47
+streamlit-extras>=0.4


### PR DESCRIPTION
## Summary
- add `streamlit-extras` requirement
- use `st_autorefresh` with a sidebar slider on UI pages
- remove the fixed 5‑second refresh loop

## Testing
- `make test`