### PR TITLE
VAL-T1 – Stabilise local test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ data:
 	@echo "CSV ready → data/news_sample.csv"
 
 test:
-	pytest -q
+	PYTHONPATH=$(CURDIR) pytest -q

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+pytest
+pytest-asyncio
+pytest-mock
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ numpy>=1.24,<2
 prometheus_client>=0.19.0
 redis>=5.0.0
 streamlit==1.34.0
-torch==2.2.1
+torch==2.2.1 ; python_version < "3.13"
 tqdm>=4.66.4
 transformers>=4.25,<4.47
 streamlit-extras>=0.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,10 @@ dummy_asyncio = types.ModuleType("redis.asyncio")
 async def dummy_from_url(*a, **k):
     raise RuntimeError("from_url not patched")
 dummy_asyncio.from_url = dummy_from_url
-
 class DummyExc(Exception):
     pass
+
+dummy_asyncio.ResponseError = DummyExc
 
 dummy_exceptions = types.SimpleNamespace(ConnectionError=DummyExc, ResponseError=DummyExc)
 

--- a/tests/test_enrich.py
+++ b/tests/test_enrich.py
@@ -105,7 +105,7 @@ async def test_stream_trim(monkeypatch):
         async def xack(self, *a, **k):
             pass
 
-        async def xtrim(self, name, maxlen=None):
+        async def xtrim(self, name, maxlen=None, approximate=False):
             if len(self.streams.get(name, [])) > maxlen:
                 self.streams[name] = self.streams[name][-maxlen:]
 

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -95,7 +95,9 @@ async def test_stream_trim(monkeypatch):
     async def fake_rconn():
         return dummy
     monkeypatch.setattr(mod, "rconn", fake_rconn)
-    monkeypatch.setattr(mod, "load_sha", lambda *_: "sha")
+    async def fake_load_sha(*_):
+        return "sha"
+    monkeypatch.setattr(mod, "load_sha", fake_load_sha)
     monkeypatch.setattr(mod, "TOPICS", ["t"])
     monkeypatch.setattr(mod, "start_http_server", lambda *a, **k: None)
     async def stop(*_a, **_k):


### PR DESCRIPTION
## Summary
- update Makefile to always set PYTHONPATH when running tests
- add empty `agents/pages/__init__.py`
- add requirements-dev.txt and conditionally pin torch
- adjust dummy modules in tests
- make failing stubs async-aware

## Testing
- `make test`