### PR TITLE
Fix timeline preview display

### DIFF
--- a/agents/app.py
+++ b/agents/app.py
@@ -1,6 +1,7 @@
 import os
 import json
 import time
+import datetime
 import random
 import pathlib
 
@@ -121,10 +122,21 @@ with tab_user:
         st.markdown("<div style='max-height:400px;overflow-y:auto'>", unsafe_allow_html=True)
         for item in feed:
             title = item.get("title", "")
-            summary = item.get("summary", "")
+            summary = item.get("summary")
             body = item.get("body", "")
             tags = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
-            ts = item.get("id", "")
+            ts_raw = item.get("id")
+            ts = ""
+            if ts_raw:
+                try:
+                    ts_part = ts_raw.split("-")[0]
+                    ts_dt = datetime.datetime.utcfromtimestamp(int(ts_part) / 1000)
+                    ts = ts_dt.isoformat() + "Z"
+                except Exception:
+                    ts = ""
+
+            if not summary:
+                summary = (body[:250] + "…") if body else ""
 
             title_line = f"**{title}**"
             with st.expander(title_line):
@@ -156,10 +168,21 @@ with tab_topic:
         st.markdown("<div style='max-height:400px;overflow-y:auto'>", unsafe_allow_html=True)
         for item in items:
             title = item.get("title", "")
-            summary = item.get("summary", "")
+            summary = item.get("summary")
             body = item.get("body", "")
             tags = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
-            ts = item.get("id", "")
+            ts_raw = item.get("id")
+            ts = ""
+            if ts_raw:
+                try:
+                    ts_part = ts_raw.split("-")[0]
+                    ts_dt = datetime.datetime.utcfromtimestamp(int(ts_part) / 1000)
+                    ts = ts_dt.isoformat() + "Z"
+                except Exception:
+                    ts = ""
+
+            if not summary:
+                summary = (body[:250] + "…") if body else ""
 
             title_line = f"**{title}**"
             with st.expander(title_line):

--- a/agents/fanout.py
+++ b/agents/fanout.py
@@ -62,6 +62,8 @@ async def main():
                             payload = {"summary": f["data"]}
                     else:
                         payload = f
+                    summary = payload.get("summary") or payload.get("body", "")[:250]
+                    payload["summary"] = summary
                     users = await r.zrange(f"user:topic:{t}", 0, -1)
                     await r.evalsha(
                         sha, 1, stream, mid, t, json.dumps(payload), FEED_MAX_LEN, TOPIC_MAX_LEN

--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -2,6 +2,7 @@ import os
 import json
 import time
 import pathlib
+import datetime
 
 import streamlit as st
 try:
@@ -99,10 +100,21 @@ if items:
     )
     for itm in items:
         title   = itm.get("title", "")
-        summary = itm.get("summary") or (itm.get("body", "")[:300] + "…")
+        summary = itm.get("summary")
         body    = itm.get("body", "")
         tags    = itm.get("tags") or ([itm.get("topic")] if itm.get("topic") else [])
-        ts      = itm.get("id", "")
+        ts_raw  = itm.get("id")
+        ts = ""
+        if ts_raw:
+            try:
+                ts_part = ts_raw.split("-")[0]
+                ts_dt = datetime.datetime.utcfromtimestamp(int(ts_part) / 1000)
+                ts = ts_dt.isoformat() + "Z"
+            except Exception:
+                ts = ""
+
+        if not summary:
+            summary = (body[:250] + "…") if body else ""
 
         tag_html = " ".join(f"<span>{t}</span>" for t in tags)
 

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -3,6 +3,7 @@ import json
 import random
 import pathlib
 import time
+import datetime
 
 import streamlit as st
 try:
@@ -113,10 +114,21 @@ if feed:
     )
     for itm in feed:
         title   = itm.get("title", "")
-        summary = itm.get("summary") or (itm.get("body", "")[:300] + "…")
+        summary = itm.get("summary")
         body    = itm.get("body", "")
         tags    = itm.get("tags") or ([itm.get("topic")] if itm.get("topic") else [])
-        ts      = itm.get("id", "")
+        ts_raw  = itm.get("id")
+        ts = ""
+        if ts_raw:
+            try:
+                ts_part = ts_raw.split("-")[0]
+                ts_dt = datetime.datetime.utcfromtimestamp(int(ts_part) / 1000)
+                ts = ts_dt.isoformat() + "Z"
+            except Exception:
+                ts = ""
+
+        if not summary:
+            summary = (body[:250] + "…") if body else ""
 
         tag_html = " ".join(f"<span>{t}</span>" for t in tags)
 


### PR DESCRIPTION
## Summary
- render readable timestamps for timeline cards
- ensure every card shows a summary preview
- clean up fanout to always set a summary
- format topic page timestamps consistently

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6839f49c7a048326a5531579db958a2e