### PR TITLE
Modernize timeline cards

### DIFF
--- a/agents/app.py
+++ b/agents/app.py
@@ -138,17 +138,19 @@ with tab_user:
             if not summary:
                 summary = (body[:250] + "…") if body else ""
 
-            title_line = f"**{title}**"
-            with st.expander(title_line):
-                st.markdown(body)
-
             tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
-            st.markdown(tag_html, unsafe_allow_html=True)
-            if summary:
-                st.markdown(summary)
-            if ts:
-                st.markdown(ts)
-            st.markdown("<hr>", unsafe_allow_html=True)
+
+            with st.container():
+                card  = f"<div class='card'><details open><summary><h4>{title}</h4></summary>"
+                if summary:
+                    card += f"<p>{summary}</p>"
+                if body:
+                    card += f"<details><summary>Read more</summary>{body}</details>"
+                card += f"<div class='tags'>{tag_html}</div>"
+                if ts:
+                    card += f"<small>{ts}</small>"
+                card += "</details></div>"
+                st.markdown(card, unsafe_allow_html=True)
         st.markdown("</div>", unsafe_allow_html=True)
     else:
         st.info("No articles yet – try another uid or wait a bit…")
@@ -184,17 +186,19 @@ with tab_topic:
             if not summary:
                 summary = (body[:250] + "…") if body else ""
 
-            title_line = f"**{title}**"
-            with st.expander(title_line):
-                st.markdown(body)
-
             tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
-            st.markdown(tag_html, unsafe_allow_html=True)
-            if summary:
-                st.markdown(summary)
-            if ts:
-                st.markdown(ts)
-            st.markdown("<hr>", unsafe_allow_html=True)
+
+            with st.container():
+                card  = f"<div class='card'><details open><summary><h4>{title}</h4></summary>"
+                if summary:
+                    card += f"<p>{summary}</p>"
+                if body:
+                    card += f"<details><summary>Read more</summary>{body}</details>"
+                card += f"<div class='tags'>{tag_html}</div>"
+                if ts:
+                    card += f"<small>{ts}</small>"
+                card += "</details></div>"
+                st.markdown(card, unsafe_allow_html=True)
         st.markdown("</div>", unsafe_allow_html=True)
     else:
         st.info("No items yet")

--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -127,7 +127,7 @@ if items:
 
         # ---------- card rendering -----------------------------------------
         with st.container():
-            card  = f"<div class='card'><h4>{title}</h4>"
+            card  = f"<div class='card'><details open><summary><h4>{title}</h4></summary>"
             if summary:
                 card += f"<p>{summary}</p>"
             if body:
@@ -135,7 +135,7 @@ if items:
             card += f"<div class='tags'>{tag_html}</div>"
             if ts:
                 card += f"<small>{ts}</small>"
-            card += "</div>"
+            card += "</details></div>"
             st.markdown(card, unsafe_allow_html=True)
     st.markdown("</div>", unsafe_allow_html=True)
 else:

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -132,7 +132,7 @@ if feed:
 
         # ---------- card rendering -----------------------------------------
         with st.container():
-            card = f"<div class='card'><h4>{title}</h4>"
+            card  = f"<div class='card'><details open><summary><h4>{title}</h4></summary>"
             if summary:
                 card += f"<p>{summary}</p>"
             if body:
@@ -140,7 +140,7 @@ if feed:
             card += f"<div class='tags'>{tag_html}</div>"
             if ts:
                 card += f"<small>{ts}</small>"
-            card += "</div>"
+            card += "</details></div>"
             st.markdown(card, unsafe_allow_html=True)
     st.markdown("</div>", unsafe_allow_html=True)
 else:

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,5 +1,8 @@
-.card{background:#fff;border-radius:8px;padding:1rem;margin-bottom:.75rem;box-shadow:0 2px 6px rgba(0,0,0,.05);max-width:760px;margin-left:auto;margin-right:auto}
-.card h4{margin:0 0 .25rem;font-size:1.1rem}
+.card{background:#1e1e1e;border:1px solid #333;border-radius:10px;padding:.8rem 1rem;margin:.6rem 0;box-shadow:0 1px 3px rgba(0,0,0,.4)}
+.card h4{margin:0;font-size:1rem;cursor:pointer}
+.card p{margin:.5rem 0 .6rem;font-size:.9rem;line-height:1.35}
+.card details summary{list-style:none;cursor:pointer;padding:0}
+.card small{display:block;color:#888;text-align:right;margin-top:.4rem;font-size:.7rem}
 .tags span{display:inline-block;background:#ffeb3b;border-radius:4px;padding:2px 6px;margin-right:4px;font-size:.75rem}
 .tag-int,.tag-topic{
   background:#ffeb3b;


### PR DESCRIPTION
## Summary
- update card styling to dark theme
- use `<details>` in card HTML instead of `st.expander`
- adjust Topic and main UI pages to new card format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683a16b4f67883268feecda3132ffa45