### PR TITLE
Make tags navigable

### DIFF
--- a/agents/app.py
+++ b/agents/app.py
@@ -111,7 +111,8 @@ with tab_user:
     st.subheader("Interests")
     if interests:
         tags = " ".join(
-            f"<span class='tag-int'>{t}</span>" for t in interests
+            f"<span class='tag-int'><a href='?page=Topic&name={t}' target='_self'>{t}</a></span>"
+            for t in interests
         )
         st.markdown(tags, unsafe_allow_html=True)
     else:
@@ -142,7 +143,10 @@ with tab_user:
             with st.expander(title_line):
                 st.markdown(body)
 
-            tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
+            tag_html = " ".join(
+                f"<span class='tag-topic'><a href='?page=Topic&name={t}' target='_self'>{t}</a></span>"
+                for t in tags
+            )
             st.markdown(tag_html, unsafe_allow_html=True)
             if summary:
                 st.markdown(summary)
@@ -188,7 +192,10 @@ with tab_topic:
             with st.expander(title_line):
                 st.markdown(body)
 
-            tag_html = " ".join(f"<span class='tag-topic'>{t}</span>" for t in tags)
+            tag_html = " ".join(
+                f"<span class='tag-topic'><a href='?page=Topic&name={t}' target='_self'>{t}</a></span>"
+                for t in tags
+            )
             st.markdown(tag_html, unsafe_allow_html=True)
             if summary:
                 st.markdown(summary)

--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -123,7 +123,10 @@ if items:
         if not summary:
             summary = (body[:250] + "…") if body else ""
 
-        tag_html = " ".join(f"<span>{t}</span>" for t in tags)
+        tag_html = " ".join(
+            f"<span><a href='?page=Topic&name={t}' target='_self'>{t}</a></span>"
+            for t in tags
+        )
 
         # ---------- card rendering -----------------------------------------
         with st.container():

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -128,7 +128,10 @@ if feed:
         if not summary:
             summary = (body[:250] + "…") if body else ""
 
-        tag_html = " ".join(f"<span>{t}</span>" for t in tags)
+        tag_html = " ".join(
+            f"<span><a href='?page=Topic&name={t}' target='_self'>{t}</a></span>"
+            for t in tags
+        )
 
         # ---------- card rendering -----------------------------------------
         with st.container():


### PR DESCRIPTION
## Summary
- link tags in user and topic pages to the Topic view
- keep tag styling intact

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a167d02a083269b705401e68d9813