### PR TITLE
Implement relative time helper and UI update

### DIFF
--- a/agents/app.py
+++ b/agents/app.py
@@ -1,7 +1,8 @@
 import os
 import json
 import time
-import datetime
+
+from agents.utils import reltime
 import random
 import pathlib
 
@@ -123,15 +124,7 @@ with tab_user:
             summary = item.get("summary")
             body    = item.get("body", "")
             tags    = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
-            ts_raw  = item.get("id", "")
-            ts = ""
-            if ts_raw:
-                try:
-                    ts_ms  = int(ts_raw.split("-")[0])
-                    ts_dt  = datetime.datetime.utcfromtimestamp(ts_ms / 1000)
-                    ts = ts_dt.isoformat() + "Z"
-                except Exception:
-                    pass
+            ts = reltime(item.get("id", ""))
 
             if not summary:
                 summary = (body[:250] + "…") if body else ""
@@ -181,15 +174,7 @@ with tab_topic:
             summary = item.get("summary")
             body    = item.get("body", "")
             tags    = item.get("tags") or ([item.get("topic")] if item.get("topic") else [])
-            ts_raw  = item.get("id", "")
-            ts = ""
-            if ts_raw:
-                try:
-                    ts_ms = int(ts_raw.split("-")[0])
-                    ts_dt = datetime.datetime.utcfromtimestamp(ts_ms / 1000)
-                    ts = ts_dt.isoformat() + "Z"
-                except Exception:
-                    pass
+            ts = reltime(item.get("id", ""))
 
             if not summary:
                 summary = (body[:250] + "…") if body else ""

--- a/agents/pages/Topic.py
+++ b/agents/pages/Topic.py
@@ -2,7 +2,8 @@ import os
 import json
 import time
 import pathlib
-import datetime
+
+from agents.utils import reltime
 
 import streamlit as st
 try:
@@ -110,15 +111,7 @@ if items:
         summary = itm.get("summary")
         body    = itm.get("body", "")
         tags    = itm.get("tags") or ([itm.get("topic")] if itm.get("topic") else [])
-        ts_raw  = itm.get("id")
-        ts = ""
-        if ts_raw:
-            try:
-                ts_part = ts_raw.split("-")[0]
-                ts_dt = datetime.datetime.utcfromtimestamp(int(ts_part) / 1000)
-                ts = ts_dt.isoformat() + "Z"
-            except Exception:
-                ts = ""
+        ts = reltime(itm.get("id", ""))
 
         if not summary:
             summary = (body[:250] + "…") if body else ""

--- a/agents/ui.py
+++ b/agents/ui.py
@@ -3,7 +3,8 @@ import json
 import random
 import pathlib
 import time
-import datetime
+
+from agents.utils import reltime
 
 import streamlit as st
 try:
@@ -115,15 +116,7 @@ if feed:
         summary = itm.get("summary")
         body    = itm.get("body", "")
         tags    = itm.get("tags") or ([itm.get("topic")] if itm.get("topic") else [])
-        ts_raw  = itm.get("id")
-        ts = ""
-        if ts_raw:
-            try:
-                ts_part = ts_raw.split("-")[0]
-                ts_dt = datetime.datetime.utcfromtimestamp(int(ts_part) / 1000)
-                ts = ts_dt.isoformat() + "Z"
-            except Exception:
-                ts = ""
+        ts = reltime(itm.get("id", ""))
 
         if not summary:
             summary = (body[:250] + "…") if body else ""

--- a/agents/utils.py
+++ b/agents/utils.py
@@ -1,7 +1,25 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 import redis.asyncio as redis
 
 def redis_client() -> redis.Redis:
     return redis.Redis(host=os.getenv("VALKEY_HOST", "localhost"), decode_responses=True)
+
+
+def reltime(raw_id: str) -> str:
+    """Convert Valkey stream entry-id to human-friendly relative time."""
+    try:
+        ms = int(raw_id.split("-")[0])
+        dt = datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+        delta = (datetime.now(timezone.utc) - dt).total_seconds()
+        if delta < 90:
+            return f"{int(delta)} s ago"
+        if delta < 5400:
+            return f"{int(delta/60)} m ago"
+        if delta < 172800:
+            return f"{int(delta/3600)} h ago"
+        return dt.strftime("%d %b")
+    except Exception:
+        return ""

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,4 +1,5 @@
 .card{background:#1e1e1e;border:1px solid #333;border-radius:10px;padding:.8rem 1rem;margin:.6rem 0;box-shadow:0 1px 3px rgba(0,0,0,.4)}
+.card:hover{background:#1a1a1a}
 .card h4{margin:0;font-size:1rem;cursor:pointer}
 .card p{margin:.5rem 0 .6rem;font-size:.9rem;line-height:1.35}
 .card details summary{list-style:none;cursor:pointer;padding:0}


### PR DESCRIPTION
## Summary
- add `reltime` helper to convert Valkey stream ids into short timestamps
- show relative time on all timeline cards
- highlight timeline cards on hover
- refactor UI files to use the shared helper

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683a196175a08326a7342408e2b5e738