### PR TITLE
Fix `make down` to stop orphan containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dev:
 	 docker compose --profile cpu up --build -d
 
 down:
-	docker compose down
+	docker compose down --remove-orphans
 
 clear:
 	docker compose down -v


### PR DESCRIPTION
## Summary
- stop any orphan containers when running `make down`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6840c99d98508326b15c0a773577341b