### PR TITLE
Fix compose 'down' to remove enrich jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dev:
 	 docker compose --profile cpu up --build -d
 
 down:
-	docker compose down --remove-orphans
+       COMPOSE_PROFILES=cpu,gpu docker compose down --remove-orphans
 
 clear:
 	docker compose down -v


### PR DESCRIPTION
## Summary
- ensure all enrich containers are removed when running `make down`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841e0973340832696cc9801bb9b2476