### PR TITLE
Fix websocket support in gateway

### DIFF
--- a/api_gateway/Dockerfile
+++ b/api_gateway/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY . /app
-RUN pip install --no-cache-dir fastapi uvicorn redis
+RUN pip install --no-cache-dir fastapi 'uvicorn[standard]' redis
 CMD ["uvicorn", "api_gateway.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api_gateway/tests/test_gateway.py
+++ b/api_gateway/tests/test_gateway.py
@@ -22,3 +22,10 @@ async def test_topic_endpoint(dummy_stream):
     with client.websocket_connect('/ws/topic/news') as ws:
         assert ws.receive_json() == {'text': 'hello'}
         assert ws.receive_json() == {'text': 'world'}
+
+
+def test_websockets_installed():
+    """Ensure the websockets library is available for uvicorn."""
+    import importlib.util
+
+    assert importlib.util.find_spec("websockets") is not None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fastapi>=0.110
-uvicorn>=0.29
+uvicorn[standard]>=0.29
 datasets>=2.18.0
 langchain-community>=0.2.0
 numpy>=1.24,<2


### PR DESCRIPTION
## Summary
- install uvicorn with websockets support
- ensure gateway image has websockets available
- add regression test for websockets package

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841e2b846e48326b7eddc101c5e3090