### PR TITLE
Fix docker ui build

### DIFF
--- a/ui-react/Dockerfile
+++ b/ui-react/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20-alpine as build
 WORKDIR /app
-COPY package*.json ./
+COPY package.json package-lock.json ./
 RUN npm ci
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- ensure `npm ci` sees the lock file when building the React UI

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6841e53efad083269d85eac3b8ccf9ab