### PR TITLE
Fix gateway missing stream initialization

### DIFF
--- a/api_gateway/api_gateway/main.py
+++ b/api_gateway/api_gateway/main.py
@@ -1,9 +1,18 @@
 from fastapi import FastAPI, WebSocket, Depends
 from .stream import IStream
+from .redis_stream import RedisStream
+import os
 
 app = FastAPI()
 
 stream: IStream | None = None
+
+@app.on_event("startup")
+async def init_stream():
+    """Configure default stream if not provided."""
+    global stream
+    if stream is None:
+        stream = RedisStream(os.getenv("VALKEY_URL", "redis://localhost:6379"))
 
 def get_stream() -> IStream:
     assert stream is not None, "Stream not configured"

--- a/api_gateway/api_gateway/redis_stream.py
+++ b/api_gateway/api_gateway/redis_stream.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import AsyncIterator, Any
+import redis.asyncio as redis
+
+from .stream import IStream
+
+class RedisStream(IStream):
+    def __init__(self, url: str | None = None) -> None:
+        self.url = url or os.getenv("VALKEY_URL", "redis://localhost:6379")
+        self._conn: redis.Redis | None = None
+
+    async def _conn_ready(self) -> redis.Redis:
+        if self._conn is None:
+            self._conn = await redis.from_url(self.url, decode_responses=True)
+        return self._conn
+
+    async def subscribe(self, channel: str) -> AsyncIterator[Any]:
+        r = await self._conn_ready()
+        if channel.startswith("topic:"):
+            last_id = "$"
+            while True:
+                msgs = await r.xread({channel: last_id}, block=0, count=1)
+                if not msgs:
+                    continue
+                _, entries = msgs[0]
+                for entry_id, data in entries:
+                    last_id = entry_id
+                    payload = data.get("data")
+                    if payload is None:
+                        yield data
+                    else:
+                        try:
+                            yield json.loads(payload)
+                        except Exception:
+                            yield payload
+        elif channel.startswith("feed:"):
+            while True:
+                item = await r.brpop(channel, timeout=0)
+                if item is None:
+                    continue
+                _, value = item
+                try:
+                    yield json.loads(value)
+                except Exception:
+                    yield value
+        else:
+            raise ValueError(f"unknown channel {channel}")


### PR DESCRIPTION
## Summary
- add a Redis-backed stream implementation for the gateway
- auto configure the gateway to use RedisStream via startup event

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68420b8d0f188326af7d87514f4e117f