### PR TITLE
Fix make down target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ dev:
 	 docker compose --profile cpu up --build -d
 
 down:
-       COMPOSE_PROFILES=cpu,gpu docker compose down --remove-orphans
+	COMPOSE_PROFILES=cpu,gpu docker compose down --remove-orphans
 
 clear:
 	docker compose down -v


### PR DESCRIPTION
## Summary
- fix `make down` by using a tab for the recipe

## Testing
- `make down` *(fails: `/bin/sh: 1: docker: not found`)*
- `make test` *(fails: `ModuleNotFoundError: No module named 'fastapi'`)*

------
https://chatgpt.com/codex/tasks/task_e_6842167ffeb88326a432946726d0426f