### PR TITLE
Fix websocket payloads & add reconnecting socket

### DIFF
--- a/ui-react/src/App.tsx
+++ b/ui-react/src/App.tsx
@@ -1,26 +1,54 @@
+import { useState } from 'react';
 import { useFeed } from './hooks/useFeed';
 import { useTopic } from './hooks/useTopic';
 
+const TOPICS = [
+  'politics',
+  'business',
+  'technology',
+  'sports',
+  'health',
+  'climate',
+  'science',
+  'education',
+  'entertainment',
+  'finance',
+];
+
 export default function App() {
   const feed = useFeed('0');
-  const topic = useTopic('news');
+  const [slug, setSlug] = useState('technology');
+  const topic = useTopic(slug);
   return (
     <div className="space-y-4">
       <div>
         <h2 className="font-bold">Feed</h2>
         <ul>
-          {feed.map((m, i) => (
-            <li key={i}>{m.text}</li>
+          {feed.messages.map((m) => (
+            <li key={m.id}>{m.text}</li>
           ))}
         </ul>
+        {!feed.ready && <div>connecting…</div>}
       </div>
       <div>
         <h2 className="font-bold">Topic</h2>
+        <select
+          className="border ml-2"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+        >
+          {TOPICS.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
         <ul>
-          {topic.map((m, i) => (
-            <li key={i}>{m.text}</li>
+          {topic.messages.map((m) => (
+            <li key={m.id}>{m.text}</li>
           ))}
         </ul>
+        {!topic.ready && <div>connecting…</div>}
       </div>
     </div>
   );

--- a/ui-react/src/hooks/__tests__/useFeed.test.tsx
+++ b/ui-react/src/hooks/__tests__/useFeed.test.tsx
@@ -3,10 +3,10 @@ import { setupMockServer } from '../../../test/setupTests';
 import { useFeed } from '../useFeed';
 
 test('useFeed receives messages', async () => {
-  setupMockServer('/ws/feed/0', [{ text: 'one' }, { text: 'two' }]);
+  setupMockServer('/ws/feed/0', [{ title: 'one' }, { title: 'two' }]);
   const { result } = renderHook(() => useFeed('0'));
   await waitFor(() => {
-    expect(result.current).toHaveLength(2);
+    expect(result.current.messages).toHaveLength(2);
   });
-  expect(result.current[0].text).toBe('one');
+  expect(result.current.messages[0].text).toBe('one');
 });

--- a/ui-react/src/hooks/__tests__/useTopic.test.tsx
+++ b/ui-react/src/hooks/__tests__/useTopic.test.tsx
@@ -3,10 +3,10 @@ import { setupMockServer } from '../../../test/setupTests';
 import { useTopic } from '../useTopic';
 
 test('useTopic receives messages', async () => {
-  setupMockServer('/ws/topic/news', [{ text: 'hello' }]);
-  const { result } = renderHook(() => useTopic('news'));
+  setupMockServer('/ws/topic/technology', [{ title: 'hello' }]);
+  const { result } = renderHook(() => useTopic('technology'));
   await waitFor(() => {
-    expect(result.current).toHaveLength(1);
+    expect(result.current.messages).toHaveLength(1);
   });
-  expect(result.current[0].text).toBe('hello');
+  expect(result.current.messages[0].text).toBe('hello');
 });

--- a/ui-react/src/hooks/useFeed.ts
+++ b/ui-react/src/hooks/useFeed.ts
@@ -1,24 +1,20 @@
-import { useEffect, useState } from 'react';
+import { useSocket } from './useSocket';
 
-interface Message {
+export interface Message {
+  id: string;
   text: string;
 }
 
-function socketBase(): string {
-  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-  return `${proto}://${window.location.hostname}:8000`;
-}
-
-function useSocket(path: string) {
-  const [messages, setMessages] = useState<Message[]>([]);
-  useEffect(() => {
-    const ws = new WebSocket(`${socketBase()}${path}`);
-    ws.onmessage = (ev) => setMessages((m) => [...m, JSON.parse(ev.data)]);
-    return () => ws.close();
-  }, [path]);
-  return messages;
-}
+const normalize = (raw: any): Message => ({
+  id: raw.id ?? crypto.randomUUID(),
+  text:
+    raw.text ??
+    raw.title ??
+    raw.summary ??
+    raw.body?.slice(0, 120) ??
+    '[no-content]',
+});
 
 export function useFeed(uid: string) {
-  return useSocket(`/ws/feed/${uid}`);
+  return useSocket(`/ws/feed/${uid}`, normalize);
 }

--- a/ui-react/src/hooks/useSocket.ts
+++ b/ui-react/src/hooks/useSocket.ts
@@ -1,0 +1,56 @@
+import { useEffect, useState } from 'react';
+
+function socketBase(): string {
+  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+  return `${proto}://${window.location.hostname}:8000`;
+}
+
+export interface SocketState<T> {
+  messages: T[];
+  ready: boolean;
+}
+
+export function useSocket<T>(path: string, normalize: (raw: any) => T): SocketState<T> {
+  const [messages, setMessages] = useState<T[]>([]);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    let ws: WebSocket | null = null;
+    let retry = 0;
+
+    const connect = () => {
+      ws = new WebSocket(`${socketBase()}${path}`);
+      ws.onopen = () => {
+        if (!isMounted) return;
+        retry = 0;
+        setReady(true);
+      };
+      ws.onmessage = (ev) => {
+        if (!isMounted) return;
+        setMessages((m) => [...m, normalize(JSON.parse(ev.data))]);
+      };
+      const handleClose = () => {
+        if (!isMounted) return;
+        setReady(false);
+        retry += 1;
+        const timeout = Math.min(1000 * 2 ** retry, 5000);
+        setTimeout(() => {
+          if (isMounted) connect();
+        }, timeout);
+      };
+      ws.onclose = handleClose;
+      ws.onerror = handleClose;
+    };
+
+    connect();
+
+    return () => {
+      isMounted = false;
+      setReady(false);
+      ws?.close();
+    };
+  }, [path]);
+
+  return { messages, ready };
+}

--- a/ui-react/src/hooks/useTopic.ts
+++ b/ui-react/src/hooks/useTopic.ts
@@ -1,24 +1,20 @@
-import { useEffect, useState } from 'react';
+import { useSocket } from './useSocket';
 
-interface Message {
+export interface Message {
+  id: string;
   text: string;
 }
 
-function socketBase(): string {
-  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-  return `${proto}://${window.location.hostname}:8000`;
-}
-
-function useSocket(path: string) {
-  const [messages, setMessages] = useState<Message[]>([]);
-  useEffect(() => {
-    const ws = new WebSocket(`${socketBase()}${path}`);
-    ws.onmessage = (ev) => setMessages((m) => [...m, JSON.parse(ev.data)]);
-    return () => ws.close();
-  }, [path]);
-  return messages;
-}
+const normalize = (raw: any): Message => ({
+  id: raw.id ?? crypto.randomUUID(),
+  text:
+    raw.text ??
+    raw.title ??
+    raw.summary ??
+    raw.body?.slice(0, 120) ??
+    '[no-content]',
+});
 
 export function useTopic(slug: string) {
-  return useSocket(`/ws/topic/${slug}`);
+  return useSocket(`/ws/topic/${slug}`, normalize);
 }


### PR DESCRIPTION
## Summary
- normalize websocket payloads in feed and topic hooks
- refactor to a shared `useSocket` hook with reconnect logic and ready state
- show connection state and add topic selector in the demo app
- update tests for new message shape

## Testing
- `npm test -s --prefix ui-react`
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68421a748f988326a48b1a2c5abc0d2d