### PR TITLE
Add user selector and card layout to React UI

### DIFF
--- a/ui-react/index.html
+++ b/ui-react/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Valkey Demo</title>
   </head>
-  <body class="p-4">
+  <body class="bg-[#f7f7fa]">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/ui-react/src/App.tsx
+++ b/ui-react/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useFeed } from './hooks/useFeed';
 import { useTopic } from './hooks/useTopic';
+import { PostCard } from './components/PostCard';
 
 const TOPICS = [
   'politics',
@@ -16,39 +17,56 @@ const TOPICS = [
 ];
 
 export default function App() {
-  const feed = useFeed('0');
+  const [uid, setUid] = useState(0);
+  const feed = useFeed(String(uid));
   const [slug, setSlug] = useState('technology');
   const topic = useTopic(slug);
+
   return (
-    <div className="space-y-4">
-      <div>
-        <h2 className="font-bold">Feed</h2>
-        <ul>
-          {feed.messages.map((m) => (
-            <li key={m.id}>{m.text}</li>
-          ))}
-        </ul>
-        {!feed.ready && <div>connecting…</div>}
-      </div>
-      <div>
-        <h2 className="font-bold">Topic</h2>
-        <select
-          className="border ml-2"
-          value={slug}
-          onChange={(e) => setSlug(e.target.value)}
-        >
-          {TOPICS.map((t) => (
-            <option key={t} value={t}>
-              {t}
-            </option>
-          ))}
-        </select>
-        <ul>
-          {topic.messages.map((m) => (
-            <li key={m.id}>{m.text}</li>
-          ))}
-        </ul>
-        {!topic.ready && <div>connecting…</div>}
+    <div className="min-h-screen bg-[#f7f7fa]">
+      <header className="sticky top-0 bg-[#f7f7fa] py-4 mb-4 shadow-sm">
+        <div className="max-w-3xl mx-auto flex items-end gap-4">
+          <h1 className="text-xl font-bold flex-1">Valkey Agentic Demo</h1>
+          <label className="text-sm">User ID</label>
+          <input
+            type="number"
+            className="border rounded px-2 py-1 w-20"
+            value={uid}
+            min={0}
+            onChange={(e) => setUid(Number(e.target.value))}
+          />
+          <select
+            className="border rounded px-2 py-1"
+            value={slug}
+            onChange={(e) => setSlug(e.target.value)}
+          >
+            {TOPICS.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+      <div className="max-w-3xl mx-auto space-y-6">
+        <div>
+          <h2 className="font-bold mb-2">Feed</h2>
+          <div className="space-y-3">
+            {feed.messages.map((m) => (
+              <PostCard key={m.id} {...m} />
+            ))}
+          </div>
+          {!feed.ready && <div>connecting…</div>}
+        </div>
+        <div>
+          <h2 className="font-bold mb-2">Topic</h2>
+          <div className="space-y-3">
+            {topic.messages.map((m) => (
+              <PostCard key={m.id} {...m} />
+            ))}
+          </div>
+          {!topic.ready && <div>connecting…</div>}
+        </div>
       </div>
     </div>
   );

--- a/ui-react/src/components/PostCard.tsx
+++ b/ui-react/src/components/PostCard.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { TagChip } from './TagChip';
+
+export interface PostCardProps {
+  title: string;
+  summary?: string;
+  body?: string;
+  tags?: string[];
+  topic?: string;
+}
+
+export function PostCard({ title, summary, body, tags = [], topic }: PostCardProps) {
+  const chips = Array.from(new Set([...(tags ?? []), topic].filter(Boolean)));
+  return (
+    <div className="rounded-2xl shadow-sm p-4 bg-white">
+      <h3 className="font-bold truncate" title={title}>
+        {title}
+      </h3>
+      {summary || body ? (
+        <p className="text-sm text-slate-700 line-clamp-2 mt-1">
+          {summary ?? body}
+        </p>
+      ) : null}
+      <div className="mt-2">
+        {chips.map((t) => (
+          <TagChip key={t} label={t} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ui-react/src/components/TagChip.tsx
+++ b/ui-react/src/components/TagChip.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export interface TagChipProps {
+  label: string;
+}
+
+export function TagChip({ label }: TagChipProps) {
+  return (
+    <span className="inline-flex items-center px-2 py-0.5 bg-slate-100 text-xs rounded-full mr-1">
+      {label}
+    </span>
+  );
+}

--- a/ui-react/src/components/__tests__/PostCard.test.tsx
+++ b/ui-react/src/components/__tests__/PostCard.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import { PostCard } from '../PostCard';
+
+it('renders title, summary and tags', () => {
+  render(
+    <PostCard title="hello" summary="world" tags={['t1']} topic="tech" />
+  );
+  expect(screen.getByText('hello')).toBeInTheDocument();
+  expect(screen.getByText('world')).toBeInTheDocument();
+  // two chips: t1 and tech
+  expect(screen.getByText('t1')).toBeInTheDocument();
+  expect(screen.getByText('tech')).toBeInTheDocument();
+});

--- a/ui-react/src/hooks/__tests__/useFeed.test.tsx
+++ b/ui-react/src/hooks/__tests__/useFeed.test.tsx
@@ -8,5 +8,18 @@ test('useFeed receives messages', async () => {
   await waitFor(() => {
     expect(result.current.messages).toHaveLength(2);
   });
-  expect(result.current.messages[0].text).toBe('one');
+  expect(result.current.messages[0].title).toBe('one');
+});
+
+test('useFeed re-subscribes when uid changes', async () => {
+  setupMockServer('/ws/feed/0', [{ title: 'a0' }]);
+  setupMockServer('/ws/feed/1', [{ title: 'b1' }]);
+  const { result, rerender } = renderHook(({ uid }) => useFeed(uid), {
+    initialProps: { uid: '0' },
+  });
+  await waitFor(() => expect(result.current.messages).toHaveLength(1));
+  expect(result.current.messages[0].title).toBe('a0');
+  rerender({ uid: '1' });
+  await waitFor(() => expect(result.current.messages).toHaveLength(1));
+  expect(result.current.messages[0].title).toBe('b1');
 });

--- a/ui-react/src/hooks/__tests__/useTopic.test.tsx
+++ b/ui-react/src/hooks/__tests__/useTopic.test.tsx
@@ -8,5 +8,5 @@ test('useTopic receives messages', async () => {
   await waitFor(() => {
     expect(result.current.messages).toHaveLength(1);
   });
-  expect(result.current.messages[0].text).toBe('hello');
+  expect(result.current.messages[0].title).toBe('hello');
 });

--- a/ui-react/src/hooks/useFeed.ts
+++ b/ui-react/src/hooks/useFeed.ts
@@ -2,17 +2,20 @@ import { useSocket } from './useSocket';
 
 export interface Message {
   id: string;
-  text: string;
+  title: string;
+  summary?: string;
+  body?: string;
+  tags: string[];
+  topic?: string;
 }
 
 const normalize = (raw: any): Message => ({
   id: raw.id ?? crypto.randomUUID(),
-  text:
-    raw.text ??
-    raw.title ??
-    raw.summary ??
-    raw.body?.slice(0, 120) ??
-    '[no-content]',
+  title: raw.title ?? raw.text ?? '[no-title]',
+  summary: raw.summary ?? raw.body ?? raw.text,
+  body: raw.body,
+  tags: raw.tags ?? (raw.topic ? [raw.topic] : []),
+  topic: raw.topic,
 });
 
 export function useFeed(uid: string) {

--- a/ui-react/src/hooks/useSocket.ts
+++ b/ui-react/src/hooks/useSocket.ts
@@ -15,6 +15,7 @@ export function useSocket<T>(path: string, normalize: (raw: any) => T): SocketSt
   const [ready, setReady] = useState(false);
 
   useEffect(() => {
+    setMessages([]);
     let isMounted = true;
     let ws: WebSocket | null = null;
     let retry = 0;

--- a/ui-react/src/hooks/useTopic.ts
+++ b/ui-react/src/hooks/useTopic.ts
@@ -2,17 +2,20 @@ import { useSocket } from './useSocket';
 
 export interface Message {
   id: string;
-  text: string;
+  title: string;
+  summary?: string;
+  body?: string;
+  tags: string[];
+  topic?: string;
 }
 
 const normalize = (raw: any): Message => ({
   id: raw.id ?? crypto.randomUUID(),
-  text:
-    raw.text ??
-    raw.title ??
-    raw.summary ??
-    raw.body?.slice(0, 120) ??
-    '[no-content]',
+  title: raw.title ?? raw.text ?? '[no-title]',
+  summary: raw.summary ?? raw.body ?? raw.text,
+  body: raw.body,
+  tags: raw.tags ?? (raw.topic ? [raw.topic] : []),
+  topic: raw.topic,
 });
 
 export function useTopic(slug: string) {

--- a/ui-react/test/setupTests.ts
+++ b/ui-react/test/setupTests.ts
@@ -1,4 +1,5 @@
 import { afterEach } from 'vitest';
+import '@testing-library/jest-dom';
 import { Server } from 'mock-socket';
 
 const servers: Server[] = [];


### PR DESCRIPTION
## Summary
- add `PostCard` and `TagChip` components
- style feed and topic panes with cards
- introduce User ID selector and sticky header
- normalize feed/topic messages for new fields
- reset socket messages on path change
- expand tests for feed hook and add card component test

## Testing
- `npm test --prefix ui-react`
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684220615b7c8326a10f1ab201e242bf