### PR TITLE
Reset topic filter when UID changes

### DIFF
--- a/ui-react/src/__tests__/app.test.tsx
+++ b/ui-react/src/__tests__/app.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { setupMockServer } from '../../test/setupTests';
+import App from '../App';
+
+vi.stubGlobal('fetch', vi.fn((url: string) => {
+  if (url.endsWith('/user/0')) {
+    return Promise.resolve(new Response(JSON.stringify({ interests: ['foo', 'bar'] })));
+  }
+  if (url.endsWith('/user/1')) {
+    return Promise.resolve(new Response(JSON.stringify({ interests: ['baz'] })));
+  }
+  return Promise.resolve(new Response('null', { status: 404 }));
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test('topic filter resets when uid changes', async () => {
+  setupMockServer('/ws/feed/0?backlog=100', [
+    { title: 'p0', topic: 'foo' },
+    { title: 'p1', topic: 'bar' }
+  ]);
+  setupMockServer('/ws/feed/1?backlog=100', [{ title: 'x', topic: 'baz' }]);
+
+  const { rerender } = render(<App initialUid="0" />);
+  await waitFor(() => expect(document.querySelectorAll('details')).toHaveLength(1));
+
+  fireEvent.click(screen.getAllByText('foo')[0]);
+  expect(document.querySelectorAll('details')).toHaveLength(1);
+
+  rerender(<App initialUid="1" />);
+  await waitFor(() => expect(document.querySelectorAll('details')).toHaveLength(1));
+  expect(screen.queryByText('connecting…')).not.toBeInTheDocument();
+});

--- a/ui-react/test/e2e/feed.spec.ts
+++ b/ui-react/test/e2e/feed.spec.ts
@@ -1,24 +1,50 @@
 import { test, expect } from '@playwright/test';
 import { setupMockServer } from '../setupTests';
 
-const FEED_PATH = '/ws/feed/1?backlog=100';
+const FEED1_PATH = '/ws/feed/1?backlog=100';
+const FEED2_PATH = '/ws/feed/2?backlog=100';
 
 let server: { send: (m: string) => void; stop: () => void };
+let server2: { send: (m: string) => void; stop: () => void } | null = null;
 
 test.beforeEach(async ({ page }) => {
   server = setupMockServer(
-    FEED_PATH,
-    Array.from({ length: 10 }, (_, i) => ({ title: `post ${i}` }))
+    FEED1_PATH,
+    Array.from({ length: 10 }, (_, i) => ({ title: `post ${i}`, topic: 'foo' }))
   );
   await page.exposeFunction('serverSend', (msg: string) => server.send(msg));
 });
 
 test.afterEach(() => {
   server.stop();
+  server2?.stop();
+  server2 = null;
 });
 
 test('initial backlog shown without refresh banner', async ({ page }) => {
   await page.goto('http://localhost:8500/user/1');
   await expect(page.locator('details')).toHaveCount(10);
   await expect(page.locator('text=Refresh')).toHaveCount(0);
+});
+
+test('filter resets when navigating between users', async ({ page }) => {
+  server2 = setupMockServer(FEED2_PATH, [{ title: 'other', topic: 'bar' }]);
+  await page.route('http://localhost:8000/user/1', async route => {
+    await route.fulfill({ status: 200, body: JSON.stringify({ interests: ['foo'] }) });
+  });
+  await page.route('http://localhost:8000/user/2', async route => {
+    await route.fulfill({ status: 200, body: JSON.stringify({ interests: ['bar'] }) });
+  });
+
+  await page.goto('http://localhost:8500/user/1');
+  await expect(page.locator('details')).toHaveCount(10);
+  await page.click('text=foo');
+
+  await page.goto('http://localhost:8500/user/2');
+  await expect(page.locator('details')).toHaveCount(1);
+  await expect(page.locator('text=connecting…')).toHaveCount(0);
+
+  await page.goto('http://localhost:8500/user/1');
+  await expect(page.locator('details')).toHaveCount(10);
+  await expect(page.locator('text=connecting…')).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- clear topic filter on uid changes and validate against feed
- test App topic filter resets with rerenders
- simulate user navigation in e2e feed spec

## Testing
- `pip install -r requirements-dev.txt`
- `pip install fastapi uvicorn[standard] redis prometheus_client numpy tqdm transformers datasets langchain-community`
- `make test`
- `cd ui-react && npm install`
- `npm test`
- `npm run e2e` *(fails: TypeError: Cannot redefine property: Symbol($$jest-matchers-object))*

------
https://chatgpt.com/codex/tasks/task_e_68434fd6db2883269778c41477499dbe