### PR TITLE
Show interests filter

### DIFF
--- a/ui-react/src/App.tsx
+++ b/ui-react/src/App.tsx
@@ -44,18 +44,23 @@ export default function App({ initialUid }: { initialUid?: string }) {
         </div>
       </header>
       <div className="max-w-3xl mx-auto space-y-6">
-        {user?.interests && (
-          <div className="mb-2">
-            {user.interests.map((t) => (
-              <TagChip
-                key={t}
-                label={t}
-                active={topicFilter === t}
-                onClick={() => setActiveTopic((prev) => toggleTopic(prev, t))}
-              />
-            ))}
-          </div>
-        )}
+        {user?.interests?.length ? (
+          <section>
+            <h2 className="font-bold mb-1">Interests</h2>
+            <div className="mb-2">
+              {user.interests.map((t) => (
+                <TagChip
+                  key={t}
+                  label={t}
+                  active={topicFilter === t}
+                  onClick={() =>
+                    setActiveTopic((prev) => toggleTopic(prev, t))
+                  }
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
         {feed.pending.length > 0 && !feed.loading && (
           <button
             className="fixed top-16 right-4 bg-blue-600 text-white px-3 py-1 rounded"

--- a/ui-react/src/__tests__/interests.test.tsx
+++ b/ui-react/src/__tests__/interests.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { vi } from 'vitest';
+import { setupMockServer } from '../../test/setupTests';
+import App from '../App';
+
+vi.mock('../hooks/useUser', () => ({
+  useUser: () => ({ interests: ['tech', 'sports'] })
+}));
+
+it('filters feed when clicking interest chip', async () => {
+  setupMockServer('/ws/feed/0?backlog=100', [
+    { title: 't1', topic: 'tech' },
+    { title: 's1', topic: 'sports' }
+  ]);
+
+  render(<App initialUid="0" />);
+  await waitFor(() => expect(document.querySelectorAll('details')).toHaveLength(1));
+  fireEvent.click(screen.getByText(/Refresh/));
+  await waitFor(() => expect(document.querySelectorAll('details')).toHaveLength(2));
+
+  const section = screen.getByRole('heading', { name: 'Interests' }).parentElement as HTMLElement;
+  expect(within(section).getByText('tech')).toBeInTheDocument();
+  expect(within(section).getByText('sports')).toBeInTheDocument();
+
+  fireEvent.click(within(section).getByText('tech'));
+  expect(document.querySelectorAll('details')).toHaveLength(1);
+  expect(screen.getByText('t1')).toBeInTheDocument();
+  expect(screen.queryByText('s1')).toBeNull();
+
+  fireEvent.click(within(section).getByText('tech'));
+  expect(document.querySelectorAll('details')).toHaveLength(2);
+});
+

--- a/ui-react/src/components/TagChip.tsx
+++ b/ui-react/src/components/TagChip.tsx
@@ -11,7 +11,7 @@ export function TagChip({ label, active, onClick }: TagChipProps) {
     'inline-flex items-center px-2 py-0.5 text-xs rounded-full mr-1 cursor-pointer';
   const cls = active
     ? `${base} bg-blue-600 text-white`
-    : `${base} bg-slate-100`;
+    : `${base} bg-slate-100 text-slate-700`;
   return (
     <span className={cls} onClick={onClick}>
       {label}

--- a/ui-react/test/e2e/feed.spec.ts
+++ b/ui-react/test/e2e/feed.spec.ts
@@ -48,3 +48,24 @@ test('filter resets when navigating between users', async ({ page }) => {
   await expect(page.locator('details')).toHaveCount(10);
   await expect(page.locator('text=connecting…')).toHaveCount(0);
 });
+
+test('interest chips toggle the feed filter', async ({ page }) => {
+  server.stop();
+  server = setupMockServer(FEED1_PATH, [
+    { title: 'foo post', topic: 'foo' },
+    { title: 'bar post', topic: 'bar' }
+  ]);
+  await page.route('http://localhost:8000/user/1', async route => {
+    await route.fulfill({
+      status: 200,
+      body: JSON.stringify({ interests: ['foo', 'bar'] })
+    });
+  });
+
+  await page.goto('http://localhost:8500/user/1');
+  await expect(page.locator('details')).toHaveCount(2);
+  await page.click('text=foo');
+  await expect(page.locator('details')).toHaveCount(1);
+  await page.click('text=foo');
+  await expect(page.locator('details')).toHaveCount(2);
+});

--- a/ui-react/test/setupTests.ts
+++ b/ui-react/test/setupTests.ts
@@ -1,5 +1,8 @@
-import { afterEach } from 'vitest';
-import '@testing-library/jest-dom';
+// Only load jest-dom when running under Vitest where `expect` is provided
+// globally. Playwright tests provide their own assertion library.
+if (typeof expect !== 'undefined' && typeof (expect as any).extend === 'function') {
+  await import('@testing-library/jest-dom');
+}
 import { Server } from 'mock-socket';
 
 const servers: Server[] = [];
@@ -20,7 +23,9 @@ export function setupMockServer(path: string, messages: unknown[]) {
   } as const;
 }
 
-afterEach(() => {
-  servers.forEach((s) => s.stop());
-  servers.length = 0;
-});
+if (typeof afterEach === 'function') {
+  afterEach(() => {
+    servers.forEach((s) => s.stop());
+    servers.length = 0;
+  });
+}


### PR DESCRIPTION
## Summary
- display user's interests as clickable chips in the header
- style TagChip consistently
- test interest filtering logic
- support interest chip toggle in e2e tests
- allow setupTests to run under Playwright

## Testing
- `npm test --silent`
- `npm run e2e --silent` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684352ad45b883269b22a1e2a76725c7