### PR TITLE
Fix interest chips & dynamic user fetch

### DIFF
--- a/ui-react/src/components/TagChip.tsx
+++ b/ui-react/src/components/TagChip.tsx
@@ -12,9 +12,14 @@ export function TagChip({ label, active, onClick }: TagChipProps) {
   const cls = active
     ? `${base} bg-blue-600 text-white`
     : `${base} bg-slate-100 text-slate-700`;
+  const handle = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    onClick?.();
+  };
   return (
-    <span className={cls} onClick={onClick}>
+    <button type="button" className={cls} onClick={handle}>
       {label}
-    </span>
+    </button>
   );
 }

--- a/ui-react/src/components/__tests__/PostCard.test.tsx
+++ b/ui-react/src/components/__tests__/PostCard.test.tsx
@@ -11,3 +11,29 @@ it('renders title, summary and tags', () => {
   expect(screen.getByText('t1')).toBeInTheDocument();
   expect(screen.getByText('tech')).toBeInTheDocument();
 });
+
+import { fireEvent } from '@testing-library/react';
+import { useState } from 'react';
+import { toggleTopic } from '../../utils';
+
+test('tag chip click toggles topic without opening details', () => {
+  function Wrapper() {
+    const [topic, setTopic] = useState<string | null>(null);
+    return (
+      <PostCard
+        title="t"
+        tags={['foo']}
+        activeTopic={topic}
+        onTagClick={(t) => setTopic((prev) => toggleTopic(prev, t))}
+      />
+    );
+  }
+  const { container } = render(<Wrapper />);
+  const details = container.querySelector('details')!;
+  const chip = screen.getByRole('button', { name: 'foo' });
+  fireEvent.click(chip);
+  expect(details.hasAttribute('open')).toBe(false);
+  expect(screen.getByRole('button', { name: 'foo' }).className).toMatch('bg-blue-600');
+  fireEvent.click(screen.getByRole('button', { name: 'foo' }));
+  expect(screen.getByRole('button', { name: 'foo' }).className).not.toMatch('bg-blue-600');
+});

--- a/ui-react/src/hooks/__tests__/useUser.test.tsx
+++ b/ui-react/src/hooks/__tests__/useUser.test.tsx
@@ -1,0 +1,24 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useUser } from '../useUser';
+
+it('builds URL from window.location and returns data', async () => {
+  const originalLocation = window.location;
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { protocol: 'https:', hostname: 'demo.local' } as Location,
+  });
+  const mockFetch = vi.fn(() =>
+    Promise.resolve(new Response(JSON.stringify({ interests: ['x'] })))
+  );
+  vi.stubGlobal('fetch', mockFetch);
+
+  const { result } = renderHook(() => useUser('5'));
+  await waitFor(() => expect(result.current).not.toBeNull());
+
+  expect(mockFetch).toHaveBeenCalledWith('https://demo.local:8000/user/5');
+  expect(result.current).toEqual({ interests: ['x'] });
+
+  vi.unstubAllGlobals();
+  Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+});

--- a/ui-react/src/hooks/useUser.ts
+++ b/ui-react/src/hooks/useUser.ts
@@ -4,12 +4,17 @@ export interface User {
   interests: string[];
 }
 
+function apiBase() {
+  const { protocol, hostname } = window.location;
+  return `${protocol}//${hostname}:8000`;
+}
+
 export function useUser(uid: string | number) {
   const [user, setUser] = useState<User | null>(null);
   useEffect(() => {
     if (uid === null || uid === undefined) return;
-    fetch(`http://localhost:8000/user/${uid}`)
-      .then((res) => res.ok ? res.json() : null)
+    fetch(`${apiBase()}/user/${uid}`)
+      .then((res) => (res.ok ? res.json() : null))
       .then((data) => setUser(data))
       .catch(() => setUser(null));
   }, [uid]);

--- a/ui-react/test/e2e/feed.spec.ts
+++ b/ui-react/test/e2e/feed.spec.ts
@@ -69,3 +69,21 @@ test('interest chips toggle the feed filter', async ({ page }) => {
   await page.click('text=foo');
   await expect(page.locator('details')).toHaveCount(2);
 });
+
+test('post tag chips filter the feed', async ({ page }) => {
+  server.stop();
+  server = setupMockServer(FEED1_PATH, [
+    { title: 'foo post', topic: 'foo' },
+    { title: 'bar post', topic: 'bar' }
+  ]);
+  await page.route('http://localhost:8000/user/1', async route => {
+    await route.fulfill({ status: 200, body: '{}' });
+  });
+
+  await page.goto('http://localhost:8500/user/1');
+  await expect(page.locator('details')).toHaveCount(2);
+  await page.click('role=button[name="foo"]');
+  await expect(page.locator('details')).toHaveCount(1);
+  await page.click('role=button[name="foo"]');
+  await expect(page.locator('details')).toHaveCount(2);
+});


### PR DESCRIPTION
## Summary
- fetch user data relative to the UI origin
- prevent details toggling when tag chips are clicked
- test tag-chip behaviour and dynamic API base
- cover post tag chip filtering in e2e tests

## Testing
- `make test`
- `npm test` (from `ui-react`)
- `npm run e2e` *(fails: Timed out waiting for browser)*

------
https://chatgpt.com/codex/tasks/task_e_684359efe5b083269d3cecefbf1f1250