### PR TITLE
Improve BuildKit caching and tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
-      - run: docker compose --profile cpu build
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          cache-from: type=gha,scope=dev-img
+          cache-to: type=gha,scope=dev-img,mode=max
 
   verify-valkey:
     runs-on: ubuntu-latest

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -1,0 +1,18 @@
+name: build-tools
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/tools.Dockerfile
+          push: false
+          cache-from: type=gha,scope=dev-img
+          cache-to: type=gha,scope=dev-img,mode=max

--- a/.tools/bootstrap.sh
+++ b/.tools/bootstrap.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+command -v mockgen >/dev/null || go install github.com/golang/mock/mockgen@v1.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contributing
+
+## How the cache works
+
+The CI builds use BuildKit layer caching via GitHub Actions. Layers are stored under the `dev-img` scope so repeated runs can reuse them. When the Dockerfile or dependencies change, the cache automatically invalidates and the image rebuilds. Otherwise, jobs start much faster because the cached layers are restored.
+
+To run the development container with your local tool cache mounted:
+
+```bash
+docker run --rm --platform=linux/amd64 \
+  -v "$PWD/.tools:/usr/local/.tools:ro" \
+  -e PATH=/usr/local/.tools/bin:$PATH \
+  vomu-dev-amd64 task ci:core
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,10 @@ FROM python:3.12-slim AS builder
 ENV HF_HOME=/opt/hf_cache \
     HF_HUB_DISABLE_XET=1
 WORKDIR /app
+COPY .tools /usr/local/.tools
+ENV PATH=/usr/local/.tools/bin:$PATH
+RUN apt-get update && apt-get install -y golang-go && rm -rf /var/lib/apt/lists/*
+RUN command -v mockgen >/dev/null || go install github.com/golang/mock/mockgen@v1.6.0
 
 COPY requirements.txt .
 RUN pip install --no-cache-dir --prefix=/install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -73,3 +73,5 @@ Feel free to modify the services or compose file to experiment further!
 
 Both `/ws/feed/{uid}` and `/ws/topic/{slug}` accept an optional `backlog` query
 parameter to stream the latest N items on connect.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on the CI build cache and the development container.

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,0 +1,5 @@
+ARG ORG
+FROM ghcr.io/${ORG}/vomu-tools:${{ github.date }}
+ENV PATH=/usr/local/.tools/bin:$PATH
+WORKDIR /app
+COPY . /app

--- a/docker/tools.Dockerfile
+++ b/docker/tools.Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.19
+RUN apk add --no-cache go git build-base
+COPY .tools /usr/local/.tools
+ENV PATH=/usr/local/.tools/bin:$PATH
+RUN /usr/local/.tools/bootstrap.sh


### PR DESCRIPTION
## Summary
- bootstrap dev tools with a version-pinned script
- reuse cached tools inside the Docker image
- persist Docker layers in CI using build-push-action
- document layer caching in CONTRIBUTING

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684da1d273008326874b39c659072a71