### PR TITLE
Fix tests by including runtime deps for development

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
+# Development requirements include runtime dependencies
+-r requirements.txt
+
 pytest>=7.4,<8          # 8.x breaks with pytest-asyncio<0.24
 pytest-asyncio>=0.23.5,<0.24
 pytest-mock


### PR DESCRIPTION
## Summary
- ensure `requirements-dev.txt` installs runtime requirements too

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6855bbc348c4832684e960ea1dff0e47